### PR TITLE
fixed sample ordering issue for running calcISAFBeta and added a check

### DIFF
--- a/R/pcrelate2.R
+++ b/R/pcrelate2.R
@@ -233,8 +233,7 @@ setMethod("pcrelate",
 ### function to match samples and create PC matrix
 .createPCMatrix <- function(pcs, sample.include){
     # subset and re-order pcs if needed
-    # V <- pcs[match(sample.include, rownames(pcs)), , drop = FALSE]
-    V <- pcs[rownames(pcs) %in% sample.include, , drop = FALSE]
+    V <- pcs[match(sample.include, rownames(pcs)), , drop = FALSE]
     # append intercept
     V <- cbind(rep(1, nrow(V)), V)
     return(V)

--- a/R/pcrelate2.R
+++ b/R/pcrelate2.R
@@ -233,7 +233,8 @@ setMethod("pcrelate",
 ### function to match samples and create PC matrix
 .createPCMatrix <- function(pcs, sample.include){
     # subset and re-order pcs if needed
-    V <- pcs[match(sample.include, rownames(pcs)), , drop = FALSE]
+    # V <- pcs[match(sample.include, rownames(pcs)), , drop = FALSE]
+    V <- pcs[rownames(pcs) %in% sample.include, , drop = FALSE]
     # append intercept
     V <- cbind(rep(1, nrow(V)), V)
     return(V)
@@ -257,12 +258,14 @@ setMethod("pcrelate",
 # function to do actual calculation of betas
 .calcISAFBeta <- function(G, VVtVi){
 	# impute missing genotype values
-        G <- .meanImpute(G, freq=0.5*colMeans(G, na.rm=TRUE))
+    G <- .meanImpute(G, freq=0.5*colMeans(G, na.rm=TRUE))
 
 	# calculate beta
 	if(is.null(VVtVi$idx)){
+		if(!identical(rownames(G), rownames(VVtVi$val))) stop('sample order in genotypes and pcs do not match')
 		beta <- crossprod(G, VVtVi$val)
 	}else{
+		if(!identical(rownames(G)[VVtVi$idx], rownames(VVtVi$val))) stop('sample order in genotypes and pcs do not match')
 		beta <- crossprod(G[VVtVi$idx, ], VVtVi$val)
 	}
 	return(beta)
@@ -708,8 +711,8 @@ calcISAFBeta <- function(gdsobj, pcs, sample.include, training.set = NULL, snp.i
 ### exported function that does the pcrelate estimation for a (pair of) sample block(s)
 pcrelateSampBlock <- function(gdsobj, betaobj, pcs, sample.include.block1, sample.include.block2, scale, ibd.probs, maf.thresh, maf.bound.method, verbose = TRUE){
 
-        # create (joint) PC matrix and indices
-        sample.include <- unique(c(sample.include.block1, sample.include.block2))
+    # create (joint) PC matrix and indices
+    sample.include <- unique(c(sample.include.block1, sample.include.block2))
 	V <- .createPCMatrix(pcs = pcs, sample.include = sample.include)
 	idx <- which(rownames(V) %in% sample.include.block1)
 	jdx <- which(rownames(V) %in% sample.include.block2)
@@ -726,8 +729,8 @@ pcrelateSampBlock <- function(gdsobj, betaobj, pcs, sample.include.block1, sampl
 	## }else{
 	## 	snp.blocks <- list(snp.include)
 	## }
-        snp.blocks <- .snpBlocks(gdsobj)
-        nsnpblock <- length(snp.blocks)
+    snp.blocks <- .snpBlocks(gdsobj)
+    nsnpblock <- length(snp.blocks)
 
 	if(verbose) message('Running PC-Relate analysis using ', length(unlist(snp.blocks)), ' SNPs in ', nsnpblock, ' blocks...')
 	# compute estimates for each variant block; sum along the way
@@ -736,7 +739,7 @@ pcrelateSampBlock <- function(gdsobj, betaobj, pcs, sample.include.block1, sampl
 		# read genotype data for the block
 		#seqSetFilter(gdsobj, variant.id = snp.blocks[[k]])
 		#G <- altDosage(gdsobj)
-                G <- .readGeno(gdsobj, sample.include, snp.index = snp.blocks[[k]])
+        G <- .readGeno(gdsobj, sample.include, snp.index = snp.blocks[[k]])
 
 		# load betas for the current block of variants
 		#beta.block <- betaobj[rownames(betaobj) %in% snp.blocks[[k]], , drop = FALSE]


### PR DESCRIPTION
Can you take a quick look at this; we need to update this for Caitlin to run pcrelate in the parallelized way.  I did two things:
1) Changed the way pcs are subset to sample.include in .createPCMatrix. The pcs used to be reordered by sample.include; now they are not.
2) Added sample order checks to .calcISAFBeta