### PR TITLE
add option to read dosage from DS field instead of genotypes

### DIFF
--- a/R/assocTestAggregate.R
+++ b/R/assocTestAggregate.R
@@ -7,7 +7,7 @@ setMethod("assocTestAggregate",
                    test=c("Burden", "SKAT", "SMMAT"),
                    burden.test=c("Score", "Wald"), rho=0,
                    pval.method=c("davies", "kuonen", "liu"),
-                   sparse=TRUE, verbose=TRUE) {
+                   sparse=TRUE, imputed=FALSE, verbose=TRUE) {
 
               # check argument values
               test <- match.arg(test)
@@ -32,7 +32,11 @@ setMethod("assocTestAggregate",
               while (iterate) {
                   var.info <- variantInfo(gdsobj, alleles=match.alleles, expanded=TRUE)
                   
-                  geno <- expandedAltDosage(gdsobj, use.names=FALSE, sparse=sparse)[sample.index,,drop=FALSE]
+                  if (!imputed) {
+                      geno <- expandedAltDosage(gdsobj, use.names=FALSE, sparse=sparse)[sample.index,,drop=FALSE]
+                  } else {
+                      geno <- imputedDosage(gdsobj, use.names=FALSE)[sample.index,,drop=FALSE]
+                  }
 
                   if (match.alleles) {
                       index <- .matchAlleles(gdsobj, var.info)

--- a/R/assocTestSingle.R
+++ b/R/assocTestSingle.R
@@ -4,7 +4,7 @@ setGeneric("assocTestSingle", function(gdsobj, ...) standardGeneric("assocTestSi
 ## do we want to make imputing to the mean optional?
 setMethod("assocTestSingle",
           "SeqVarIterator",
-          function(gdsobj, null.model, test=c("Score", "Wald"), GxE=NULL, sparse=TRUE, verbose=TRUE) {
+          function(gdsobj, null.model, test=c("Score", "Wald"), GxE=NULL, sparse=TRUE, imputed=FALSE, verbose=TRUE) {
               test <- match.arg(test)
 
               # coerce null.model if necessary
@@ -20,8 +20,12 @@ setMethod("assocTestSingle",
               iterate <- TRUE
               while (iterate) {
                   var.info <- variantInfo(gdsobj, alleles=FALSE, expanded=TRUE)
-                  
-                  geno <- expandedAltDosage(gdsobj, use.names=FALSE, sparse=sparse)[sample.index,,drop=FALSE]
+
+                  if (!imputed) {
+                      geno <- expandedAltDosage(gdsobj, use.names=FALSE, sparse=sparse)[sample.index,,drop=FALSE]
+                  } else {
+                      geno <- imputedDosage(gdsobj, use.names=FALSE)[sample.index,,drop=FALSE]
+                  }
                   
                   # allele frequency
                   freq <- .alleleFreq(gdsobj, geno, sample.index=sample.index)

--- a/man/assocTestAggregate.Rd
+++ b/man/assocTestAggregate.Rd
@@ -13,7 +13,7 @@
                    test=c("Burden", "SKAT", "SMMAT"),
                    burden.test=c("Score", "Wald"), rho=0,
                    pval.method=c("davies", "kuonen", "liu"),
-                   sparse=TRUE, verbose=TRUE)
+                   sparse=TRUE, imputed=FALSE, verbose=TRUE)
 \S4method{assocTestAggregate}{GenotypeIterator}(gdsobj, null.model, AF.max=1,
                    weight.beta=c(1,1), weight.user=NULL,
                    test=c("Burden", "SKAT", "SMMAT"),
@@ -39,6 +39,7 @@
     method generates an error, kuonen is tried, and then liu as a last
     resort.}
     \item{sparse}{Logical indicator of whether to read genotypes as sparse Matrix objects; the default is \code{TRUE}. Set this to \code{FALSE} if the alternate allele dosage of the genotypes in the test are not expected to be mostly 0.}
+    \item{imputed}{Logical indicator of whether to read dosages from the "DS" field containing imputed dosages instead of counting the number of alternate alleles.}
     \item{verbose}{Logical indicator of whether updates from the function should be printed to the console; the default is \code{TRUE}.}
 }
 

--- a/man/assocTestSingle.Rd
+++ b/man/assocTestSingle.Rd
@@ -11,7 +11,7 @@
 
 \usage{
 \S4method{assocTestSingle}{SeqVarIterator}(gdsobj, null.model, test=c("Score", "Wald"),
-                GxE=NULL, sparse=TRUE, verbose=TRUE)
+                GxE=NULL, sparse=TRUE, imputed=FALSE, verbose=TRUE)
 \S4method{assocTestSingle}{GenotypeIterator}(gdsobj, null.model, test=c("Score", "Wald"),
                 GxE=NULL, verbose=TRUE)
 }
@@ -24,6 +24,7 @@
     \item{GxE}{A vector of character strings specifying the names of the variables for which a genotype interaction term should be included. If \code{NULL} (default) no genotype interactions are included. See 'Details' for further information.}
     %\item{ivar.return.betaCov}{Logical indicator of whether the estimated covariance matrix of the effect size estimates (betas) for the genotype and genotype interaction terms should be returned; the default is FALSE.}
     \item{sparse}{Logical indicator of whether to read genotypes as sparse Matrix objects; the default is \code{TRUE}. Set this to \code{FALSE} if the alternate allele dosage of the genotypes in the test are not expected to be mostly 0.}
+    \item{imputed}{Logical indicator of whether to read dosages from the "DS" field containing imputed dosages instead of counting the number of alternate alleles.}
     \item{verbose}{Logical indicator of whether updates from the function should be printed to the console; the default is \code{TRUE}.}
 }
 

--- a/tests/testthat/test_imputed.R
+++ b/tests/testthat/test_imputed.R
@@ -1,0 +1,40 @@
+context("use imputed dosage")
+library(SeqVarTools)
+
+.testImputedData <- function() {
+    gds <- SeqVarTools:::.testDosageData()
+    gds <- SeqVarData(gds)
+    sample.id <- SeqArray::seqGetData(gds, "sample.id")
+    df <- data.frame(sample.id=sample.id,
+                     sex=sample(c("M","F"), replace=TRUE, length(sample.id)),
+                     age=rnorm(length(sample.id), mean=50, sd=10),
+                     outcome=rnorm(length(sample.id), mean=10, sd=5),
+                     status=rbinom(length(sample.id), size=1, prob=0.4),
+                     stringsAsFactors=FALSE)
+    SeqVarTools::sampleData(gds) <- Biobase::AnnotatedDataFrame(df)
+    gds
+}
+
+test_that("assocTestSingle - imputed", {
+    svd <- .testImputedData()
+    seqSetFilter(svd, variant.sel=isSNV(svd), verbose=FALSE)
+    iterator <- SeqVarBlockIterator(svd, verbose=FALSE)
+    nullmod <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), verbose=FALSE)
+    assoc <- assocTestSingle(iterator, nullmod, verbose=FALSE)
+    resetIterator(iterator, verbose=FALSE)
+    assoc2 <- assocTestSingle(iterator, nullmod, imputed=TRUE, verbose=FALSE)
+    expect_equal(assoc$variant.id, assoc2$variant.id)
+    seqClose(svd)
+})
+
+test_that("assocTestAggregate - imputed", {
+    svd <- .testImputedData()
+    seqSetFilter(svd, variant.sel=isSNV(svd), verbose=FALSE)
+    iterator <- SeqVarWindowIterator(svd, windowSize=1e5, windowShift=1e5, verbose=FALSE)
+    nullmod <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), verbose=FALSE)
+    assoc <- assocTestAggregate(iterator, nullmod, verbose=FALSE)
+    resetIterator(iterator, verbose=FALSE)
+    assoc2 <- assocTestAggregate(iterator, nullmod, imputed=TRUE, verbose=FALSE)
+    expect_equal(assoc$variantInfo$variant.id, assoc2$variantInfo$variant.id)
+    seqClose(svd)
+})


### PR DESCRIPTION
Questions:
1. Will Michigan's imputation server ever return >1 dosage value per variant?
2. Is "imputedDosage" (as opposed to refDosage and altDosage which read from genotypes) a good name for the function in SeqVarTools that GENESIS is calling?
2. is "imputed=FALSE" a good name for the argument that turns on reading from the "DS" field instead of counting alleles from the genotype field?