### PR TITLE
re-enable pcair to take only a user specified unrel.set as input

### DIFF
--- a/R/pcair.R
+++ b/R/pcair.R
@@ -4,8 +4,8 @@ setOldClass("gds.class")
 setMethod("pcair",
           "gds.class",
           function(gdsobj, 
-                   kinobj,
-                   divobj,
+                   kinobj = NULL,
+                   divobj = NULL,
                    kin.thresh = 2^(-11/2),
                    div.thresh = -2^(-11/2),
                    unrel.set = NULL,
@@ -59,8 +59,8 @@ setMethod("pcair",
           })
 
 .pcair <- function(gdsobj,
-                   kinobj,
-                   divobj,
+                   kinobj = NULL,
+                   divobj = NULL,
                    kin.thresh = 2^(-11/2),
                    div.thresh = -2^(-11/2),
                    unrel.set = NULL,
@@ -70,10 +70,19 @@ setMethod("pcair",
                    verbose = TRUE,
                    ...) {
 
-    part <- pcairPartition(kinobj = kinobj, divobj = divobj,
-                           kin.thresh = kin.thresh, div.thresh = div.thresh,
-                           unrel.set = unrel.set, sample.include = sample.include,
-                           verbose = verbose)
+    if(!is.null(kinobj) & !is.null(divobj)){
+      part <- pcairPartition(kinobj = kinobj, divobj = divobj,
+                             kin.thresh = kin.thresh, div.thresh = div.thresh,
+                             unrel.set = unrel.set, sample.include = sample.include,
+                             verbose = verbose)
+
+    }else if(is.null(kinobj) & is.null(divobj)){
+      part <- .pcairPartitionUser(gdsobj = gdsobj, unrel.set = unrel.set, 
+                                  sample.include = sample.include, verbose = verbose)
+
+    }else{
+      stop('kinobj and divobj must either both be specified, or both be NULL')
+    }
 
     if(verbose){
         message(paste("Unrelated Set:", length(part$unrels), "Samples",

--- a/R/pcairPartition.R
+++ b/R/pcairPartition.R
@@ -208,7 +208,7 @@ pcairPartition <- function(kinobj, divobj,
 .pcairPartitionUser <- function(gdsobj, unrel.set = NULL, sample.include = NULL, verbose = TRUE){
 
     # get sample ids
-    sample.id <- as.character(read.gdsn(index.gdsn(gdsobj, "sample.id")))
+    sample.id <- as.character(.readSampleId(gdsobj))
     if(!is.null(sample.include)){
         if(!all(sample.include %in% sample.id)){
             warning('some samples in sample.include are not in gdsobj; they will not be included')

--- a/R/pcairPartition.R
+++ b/R/pcairPartition.R
@@ -5,6 +5,8 @@ pcairPartition <- function(kinobj, divobj,
                            sample.include = NULL,
                            verbose = TRUE){
 
+    if(verbose) message('Using kinobj and divobj to partition samples into unrelated and related sets')
+
     # sample.id from kinship matrix
     kin.id.all <- .readSampleId(kinobj)
     # sample.id from divergence matrix
@@ -200,4 +202,34 @@ pcairPartition <- function(kinobj, divobj,
     # return results
     return(list(rels = rels, unrels = unrels))
 
+}
+
+
+.pcairPartitionUser <- function(gdsobj, unrel.set = NULL, sample.include = NULL, verbose = TRUE){
+
+    # get sample ids
+    sample.id <- as.character(read.gdsn(index.gdsn(gdsobj, "sample.id")))
+    if(!is.null(sample.include)){
+        if(!all(sample.include %in% sample.id)){
+            warning('some samples in sample.include are not in gdsobj; they will not be included')
+            sample.include <- sample.include[sample.include %in% sample.id]
+        } 
+    }else{
+        sample.include <- sample.id
+    }
+    if(verbose) message('Working with ', length(sample.include), ' samples')
+
+    if(!is.null(unrel.set)){
+        if(verbose) message('Using user specified unrel.set to parition samples into unrelated and related sets')
+        if(!all(unrel.set %in% sample.include)){
+            warning('some samples in unrel.set are not in sample.include or gdsobj; they will not be included')
+            unrel.set <- unrel.set[unrel.set %in% sample.include]
+        }
+        rels <- sample.include[!(sample.include %in% unrel.set)]
+        part <- list(rels = rels, unrels = unrel.set)
+
+    }else{
+        if(verbose) message('kinobj, divobj, and unrel.set all NULL; performing standard PCA analysis')
+        part <- list(rels = NULL, unrels = sample.include)
+    }  
 }

--- a/man/pcair.Rd
+++ b/man/pcair.Rd
@@ -9,7 +9,7 @@
 \title{PC-AiR: Principal Components Analysis in Related Samples}
 \description{\code{pcair} is used to perform a Principal Components Analysis using genome-wide SNP data for the detection of population structure in a sample.  Unlike a standard PCA, PC-AiR accounts for sample relatedness (known or cryptic) to provide accurate ancestry inference that is not confounded by family structure.}
 \usage{
-\S4method{pcair}{gds.class}(gdsobj, kinobj, divobj,
+\S4method{pcair}{gds.class}(gdsobj, kinobj = NULL, divobj = NULL,
                             kin.thresh = 2^(-11/2), div.thresh = -2^(-11/2),
                             unrel.set = NULL, 
                             sample.include = NULL, snp.include = NULL,

--- a/man/pcair.Rd
+++ b/man/pcair.Rd
@@ -35,10 +35,18 @@
 \details{The basic premise of PC-AiR is to partition the entire sample of individuals into an ancestry representative 'unrelated subset' and a 'related set', perform standard PCA on the 'unrelated subset', and predict PC values for the 'related subset'.
 	
 	We recommend using software that accounts for population structure to estimate pairwise kinship coefficients to be used in \code{kinobj}.  Any pair of individuals with a pairwise kinship greater than \code{kin.thresh} will be declared 'related.'  Kinship coefficient estimates from the KING-robust software are typically used as measures of ancestry divergence in \code{divobj}.  Any pair of individuals with a pairwise divergence measure less than \code{div.thresh} will be declared ancestrally 'divergent'.  Typically, \code{kin.thresh} and \code{div.thresh} are set to be the amount of error around 0 expected in the estimate for a pair of truly unrelated individuals.
+
+	There are multiple ways to partition the sample into an ancestry representative 'unrelated subset' and a 'related subset'. In all of the scenarios described below, the set of all samples is limited to those in \code{sample.include} when it is specified (i.e. not \code{NULL}): 
+
+	If \code{kinobj} is specified, \code{divobj} is specified, and \code{unrel.set = NULL}, then the PC-AiR algorithm is used to find an 'optimal' partition of all samples (see 'References' for a paper describing the PC-AiR algorithm). 
+
+	If \code{kinobj} is specified, \code{divobj} is specified, and \code{unrel.set} is specified, then all individuals with IDs in \code{unrel.set} are forced in the 'unrelated subset' and the PC-AiR algorithm is used to partition the rest of the sample; this is especially useful for including reference samples of known ancestry in the 'unrelated subset'.
+
+	If \code{kinobj = NULL}, \code{divobj = NULL}, and \code{unrel.set} is specified, then all individuals with IDs in \code{unrel.set} are put in the 'unrelated subset' and the rest of the individuals are put in the 'related subset'.
+
+	If \code{kinobj = NULL}, \code{divobj = NULL}, and \code{unrel.set = NULL}, then the function will perform a "stanadard" PCA analysis.
 	
-	\code{kinobj} and \code{divobj} may be identical.
-		
-	There are multiple ways to partition the sample into an ancestry representative 'unrelated subset' and a 'related subset'.  If \code{unrel.set = NULL}, then the PC-AiR algorithm is used to find an 'optimal' partition (see 'References' for a paper describing the algorithm).  If \code{unrel.set} is specified, then all individuals with IDs in \code{unrel.set} are forced in the 'unrelated subset' and the PC-AiR algorithm is used to partition the rest of the sample; this is especially useful for including reference samples of known ancestry in the 'unrelated subset'.
+	NOTE: \code{kinobj} and \code{divobj} may be identical, but both must be specified when using the PC-AiR algorithm to parition samples.
 }
 \value{An object of class '\code{pcair}'.  A list including:
 	\item{vectors}{A matrix of principal components; each column is a principal component. Sample IDs are provided as rownames. The number of PCs returned can be adjusted by supplying the \code{eigen.cnt} argument, which is passed to \code{\link{snpgdsPCA}}.}

--- a/tests/testthat/test_pcair.R
+++ b/tests/testthat/test_pcair.R
@@ -55,3 +55,32 @@ test_that("SeqVarData", {
     expect_equal(mypcs$nsamp, 90)
     seqClose(gds)
 })
+
+
+test_that("kinobj and divobj NULL", {
+    showfile.gds(closeall=TRUE)
+    gdsfile <- system.file("extdata", "HapMap_ASW_MXL_geno.gds", package="GENESIS")
+    gds <- openfn.gds(gdsfile)
+    data("HapMap_ASW_MXL_KINGmat")
+    expect_error(pcair(gds, kinobj = HapMap_ASW_MXL_KINGmat, divobj = NULL, verbose=FALSE))
+    expect_error(pcair(gds, kinobj = NULL, divobj = HapMap_ASW_MXL_KINGmat, verbose=FALSE))
+
+    samp <- rownames(HapMap_ASW_MXL_KINGmat)
+    mypcs <- pcair(gds, kinobj = NULL, divobj = NULL, unrel.set=samp[1:100], verbose=FALSE)
+    expect_equal(mypcs$rels, samp[101:173])
+    expect_equal(mypcs$unrels, samp[1:100])
+    
+    mypcs <- pcair(gds, kinobj = NULL, divobj = NULL, unrel.set=samp[1:100], sample.include=samp[1:110], verbose=FALSE)
+    expect_equal(mypcs$rels, samp[101:110])
+    expect_equal(mypcs$unrels, samp[1:100])
+
+    mypcs <- pcair(gds, kinobj = NULL, divobj = NULL, sample.include=samp[1:110], verbose=FALSE)
+    expect_null(mypcs$rels)
+    expect_equal(mypcs$unrels, samp[1:110])
+
+    mypcs <- pcair(gds, verbose=FALSE)
+    expect_null(mypcs$rels)
+    expect_equal(mypcs$unrels, samp)
+    
+    closefn.gds(gds)
+})


### PR DESCRIPTION
This will solve the problem that Leon sent us earlier. There are now a couple options to run pcair()

1) Specify kinobj and divobj (with or without unrel.set specified).  This is what the current version of the code requires.

2) Leave kinobj and divobj both as NULL. 
a) If unrel.set is specified and sample.include is NULL, it will treat these samples as the unrelated set, and any other samples in gdsobj as the related set.  
b) If unrel.set is specified and sample.include is also specified, it will treat any samples in unrel.set and sample.include as the unrelated set, and any samples not in unrel.set but in sample.include as the related.set.
c) If unrel.set is also NULL, it will do a standard PCA analysis on the samples in sample.include (or gdsobj if unspecified).

3) If one of kinobj or divobj is specified and the other is NULL, it will stop with an error message.

I ran some manual tests using your testthat code. We should probably build in a couple extra tests there.