### PR TITLE
Update to inverse normalization to match Tamar's method

### DIFF
--- a/R/updateNullModOutcome.R
+++ b/R/updateNullModOutcome.R
@@ -3,7 +3,13 @@
 
 ## the names of items in the list group.idx have to match the names of the corresponding variance components!
 
-updateNullModOutcome <- function(nullmod, covMatList = NULL, rankNorm.option = c("by.group", "all"), rescale = c("none", "model", "residSD"), AIREML.tol = 1e-6, max.iter = 100, verbose = TRUE){
+updateNullModOutcome <- function(nullmod, 
+                                covMatList = NULL, 
+                                rankNorm.option = c("by.group", "all"), 
+                                rescale = c("none", "model", "residSD"), 
+                                AIREML.tol = 1e-6, 
+                                max.iter = 100, 
+                                verbose = TRUE){
 
     rankNorm.option <- match.arg(rankNorm.option)
     rescale <- match.arg(rescale)
@@ -11,6 +17,7 @@ updateNullModOutcome <- function(nullmod, covMatList = NULL, rankNorm.option = c
     if (nullmod$family$family != "gaussian") stop("Family must be gaussian")
     
     resid <- nullmod$resid.marginal
+    
     group.idx <- nullmod$group.idx
     if (!is.null(group.idx)) {
         g <- length(group.idx)
@@ -25,36 +32,48 @@ updateNullModOutcome <- function(nullmod, covMatList = NULL, rankNorm.option = c
     }
     
     ## checks that may be put into wrapper:
-    if ((rescale != "none") & is.null(group.idx)) stop("Rescaling is only done by groups, and group indices are missing.") 
-    
-    if (rankNorm.option == "by.group" & is.null(group.idx)) stop("Cannot rank normalize by group, missing group indices.")
-    
-    
-    if (rescale == "none"){
-        group.vars <- rep(1, g)
-    } else{
-        group.vars <- rep(NA, g)
-        for (i in 1:g){
-            if (rescale == "model") group.vars[i] <- .averageGroupVar(nullmod$varComp, covMatList, group.idx[i])
-            if (rescale == "residSD") group.vars[i] <- var(resid[group.idx[[i]]])
-        }
-    }
-    
+    # if ((rescale != "none") & is.null(group.idx)) stop("Rescaling is only done by groups, and group indices are missing.") 
+    if(rescale == "model" & rankNorm.option == "all") stop("Rescaling using model variance components when rank normalizing all samples together is not implemented")
     
     if (rankNorm.option == "by.group"){
+        if(is.null(group.idx)) stop("Cannot rank normalize by group, missing group indices.")
+        
+        # compute variance by group
+        if (rescale == "none"){
+            group.vars <- rep(1, g)
+        } else{
+            group.vars <- rep(NA, g)
+            for (i in 1:g){
+                if (rescale == "model") group.vars[i] <- .averageGroupVar(nullmod$varComp, covMatList, group.idx[i])
+                if (rescale == "residSD") group.vars[i] <- var(resid[group.idx[[i]]])
+            }
+        }
+
+        # rank normalize and rescale
         for (i in 1:g){
             group.resids <- .rankNorm(resid[group.idx[[i]]])
-            resid[group.idx[[i]]] <- group.resids*sqrt(group.vars[i])
-            
+            resid[group.idx[[i]]] <- group.resids*sqrt(group.vars[i])    
         }
     }
     
     if (rankNorm.option == "all"){
+
+        # compute variance
+        if(rescale == "none"){
+            all.vars <- 1
+        }else if(rescale == "residSD"){
+            all.vars <- var(resid)
+        }
+
+        # rank normalize and rescale
         resid <- .rankNorm(resid) 
-        for (i in 1:g){
-            resid[group.idx[[i]]] <- resid[group.idx[[i]]]*sqrt(group.vars[i])/sd(resid[group.idx[[i]]])
-        }    		
+        resid <- resid*sqrt(all.vars)    
     } 
+
+    # old code for rankNorm.option == "all"
+    # for (i in 1:g){
+    #     resid[group.idx[[i]]] <- resid[group.idx[[i]]]*sqrt(group.vars[i])/sd(resid[group.idx[[i]]])
+    # }
     
     ### now re-fit the null model:
     

--- a/man/fitNullModel.Rd
+++ b/man/fitNullModel.Rd
@@ -55,7 +55,7 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
   \item{...}{Arguments to pass to other methods.}
   \item{null.model}{The output of \code{fitNullModel}.}
   \item{norm.option}{Whether the normalization should be done separately within each value of \code{group.var} (\code{"by.group"}) or with all samples together (\code{"all"}).}
-  \item{rescale}{Controls whether to rescale the variance for each group after inverse-normal transform, restoring it to the original variance before the transform. \code{"none"} for no rescaling of the residuals; \code{"model"} for model-based rescaling, and \code{"residSD"} to rescale to the standard deviation of the marginal residuals.}
+  \item{rescale}{Controls whether to rescale the variance after inverse-normal transform, restoring it to the original variance before the transform. \code{"none"} for no rescaling of the residuals; \code{"model"} for model-based rescaling, and \code{"residSD"} to rescale to the standard deviation of the marginal residuals. See 'Details' for more information.}
 }
 
 \details{
@@ -70,6 +70,8 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
     Let \code{m} be the number of matrices in \code{cov.mat} and let \code{g} be the number of categories in the variable specified by \code{group.var}. The length of the \code{start} vector must be \code{(m + 1)} when \code{family} is gaussian and \code{group.var} is \code{NULL}; \code{(m + g)} when \code{family} is gaussian and \code{group.var} is specified; or m when \code{family} is not gaussian.
     
     A Newton-Raphson iterative procedure with Average Information REML (AIREML) is used to estimate the variance components of the random effects. When the Euclidean distance between the new and previous variance component estimates is less than \code{AIREML.tol}, the algorithm declares convergence of the estimates. Sometimes a variance component may approach the boundary of the parameter space at 0; step-halving is used to prevent any component from becomming negative. However, when a variance component gets near the 0 boundary, the algorithm can sometimes get "stuck", preventing the other variance components from converging; if \code{drop.zeros} is TRUE, then variance components that converge to a value less than \code{AIREML.tol} will be dropped from the model and the estimation procedure will continue with the remaining variance components.
+
+    After inverse-normal transformation, the variance rescaling is done with the same grouping; i.e. if \code{norm.option == "by.group"}, rescaling is done within each group, and if \code{norm.option == "all"}, rescaling is done with all samples.
 }
   
 \value{An object of class '\code{GENESIS.nullModel}' or '\code{GENESIS.nullMixedModel}'. A list including:


### PR DESCRIPTION
When norm.option == "by.group", everything should still work the same.

When norm.option == "all", I've allowed rescaling to happen, and it's done by the SD of the residuals across all samples.

This norm.option == "all" setup is what Tamar's method is for pooled analysis; even when there are multiple groups. I propose that we should do this as our default. We still need to update the analysis pipeline code to allow this.  Currently, the pipeline determines which norm.option to use by whether or not there is a group variable; we don't want to do this now.  We probably have to add a new optional argument, something like "norm.option" to allow users to do the inv-normalization and rescaling either by.group as we have been (we probably shouldn't remove that option), or using all samples. 

It seems like the conditional statements at the end of the null_model script can simplify down to: if doing inverse normalization, use the specified norm.option and rescale variables, where the default are "all" and "residSD" by default.