### PR TITLE
updated kingToMatrix to account for new KING --related output

### DIFF
--- a/R/makeSparseMatrix.R
+++ b/R/makeSparseMatrix.R
@@ -207,7 +207,7 @@ setGeneric("kingToMatrix", function(king, ...) standardGeneric("kingToMatrix"))
 
 setMethod("kingToMatrix",
           "character",
-          function(king, estimator, sample.include = NULL, thresh = NULL, verbose = TRUE) {
+          function(king, estimator = c("PropIBD", "Kinship"), sample.include = NULL, thresh = NULL, verbose = TRUE) {
               .kingToMatrix(file.king = king,
                             estimator = estimator,
                             sample.include = sample.include,
@@ -227,6 +227,7 @@ setMethod("kingToMatrix",
 
 .readKing <- function(x, estimator) {
     cols <- intersect(names(fread(x, nrows=0)), c("ID1", "ID2", estimator))
+    if (!(estimator %in% cols)) stop("Column ", estimator, " requested but not present in file")
     fread(x, select=cols)
 }
 

--- a/man/kin2gds.Rd
+++ b/man/kin2gds.Rd
@@ -25,7 +25,7 @@ library(gdsfmt)
 # KING results from the command-line program
 file.kin0 <- system.file("extdata", "MXL_ASW.kin0", package="GENESIS")
 file.kin <- system.file("extdata", "MXL_ASW.kin", package="GENESIS")
-KINGmat <- kingToMatrix(c(file.kin0, file.kin))
+KINGmat <- kingToMatrix(c(file.kin0, file.kin), estimator="Kinship")
 gdsfile <- tempfile()
 mat2gds(KINGmat, gdsfile)
 gds <- openfn.gds(gdsfile)

--- a/man/kingToMatrix.Rd
+++ b/man/kingToMatrix.Rd
@@ -5,7 +5,7 @@
 \title{Convert KING text output to an R Matrix}
 \description{\code{kingToMatrix} is used to extract the pairwise kinship coefficient estimates from the output text files of KING --ibdseg, KING --kinship, or KING --related and put them into an R object of class \code{Matrix}. One use of this matrix is that it can be read by the functions \code{\link{pcair}} and \code{\link{pcairPartition}}.}
 \usage{
-\S4method{kingToMatrix}{character}(king, estimator, sample.include = NULL, thresh = NULL, verbose = TRUE)
+\S4method{kingToMatrix}{character}(king, estimator = c("PropIBD", "Kinship"), sample.include = NULL, thresh = NULL, verbose = TRUE)
 \S4method{kingToMatrix}{snpgdsIBDClass}(king, sample.include = NULL, thresh = NULL, verbose = TRUE)
 }
 \arguments{
@@ -33,14 +33,14 @@ When reading command-line KING output, the \code{estimator} argument is required
 	\code{\link{pcair}} and \code{\link{pcairPartition}} for functions that use the output matrix.
 }
 \examples{
-# KING --robust
+# KING --kinship
 file.king <- c(system.file("extdata", "MXL_ASW.kin0", package="GENESIS"),
                system.file("extdata", "MXL_ASW.kin", package="GENESIS"))
-KINGmat <- kingToMatrix(file.king)
+KINGmat <- kingToMatrix(file.king, estimator="Kinship")
 
 # KING --ibdseg
 file.king <- system.file("extdata", "HapMap.seg", package="GENESIS")
-KINGmat <- kingToMatrix(file.king)
+KINGmat <- kingToMatrix(file.king, estimator="PropIBD")
 
 # SNPRelate
 library(SNPRelate)

--- a/man/kingToMatrix.Rd
+++ b/man/kingToMatrix.Rd
@@ -3,18 +3,21 @@
 \alias{kingToMatrix,character-method}
 \alias{kingToMatrix,snpgdsIBDClass-method}
 \title{Convert KING text output to an R Matrix}
-\description{\code{kingToMatrix} is used to extract the pairwise kinship coefficient estimates from the output text files of KING --ibdseg or KING --robust and put them into an R object of class \code{Matrix}. One use of this matrix is that it can be read by the functions \code{\link{pcair}} and \code{\link{pcairPartition}}.}
+\description{\code{kingToMatrix} is used to extract the pairwise kinship coefficient estimates from the output text files of KING --ibdseg, KING --kinship, or KING --related and put them into an R object of class \code{Matrix}. One use of this matrix is that it can be read by the functions \code{\link{pcair}} and \code{\link{pcairPartition}}.}
 \usage{
-\S4method{kingToMatrix}{character}(king, sample.include = NULL, thresh = NULL, verbose = TRUE)
+\S4method{kingToMatrix}{character}(king, estimator, sample.include = NULL, thresh = NULL, verbose = TRUE)
 \S4method{kingToMatrix}{snpgdsIBDClass}(king, sample.include = NULL, thresh = NULL, verbose = TRUE)
 }
 \arguments{
   \item{king}{Output from KING, either a \code{snpgdsIBDClass} object from \code{\link{snpgdsIBDKING}} or a character vector of one or more file names output from the command-line version of KING; see 'Details'.}
+  \item{estimator}{Which estimates to read in when using command-line KING output; must be either "PropIBD" or "Kinship"; see 'Details'.}
   \item{sample.include}{An optional vector of sample.id indicating all samples that should be included in the output matrix; see 'Details' for usage.}
   \item{thresh}{Kinship threshold for clustering samples to make the output matrix sparse block-diagonal. When \code{NULL}, no clustering is done. See 'Details'.}
   \item{verbose}{A logical indicating whether or not to print status updates to the console; the default is TRUE.}
 }
-\details{\code{king} can be a vector of multiple file names if your KING output is stored in multiple files; e.g. KING --robust run with family IDs returns a .kin and a .kin0 file for pairs within and not within the same family, respectively.
+\details{\code{king} can be a vector of multiple file names if your KING output is stored in multiple files; e.g. KING --kinship run with family IDs returns a .kin and a .kin0 file for pairs within and not within the same family, respectively.
+
+When reading command-line KING output, the \code{estimator} argument is required to specify which estimates to read in. When reading KING --ibdseg output, only "PropIBD" will be available; when reading KING --kinship output, only "Kinship" will be available; when reading KING --related output, both "PropIBD" and "Kinship" will be available - use this argument to select which to read. See the KING documentation for details on each estimator. 
 
 \code{sample.include} has two primary functions: 1) It can be used to subset the KING output. 2) \code{sample.include} can include sample.id not in \code{king}; this ensures that all samples will be in the output matrix when reading KING --ibdseg output, which likely does not contain all pairs. When left \code{NULL}, the function will determine the list of samples from what is observed in \code{king}. It is recommended to use \code{sample.include} to ensure all of your samples are included in the output matrix.
 

--- a/tests/testthat/test_kingToMatrix.R
+++ b/tests/testthat/test_kingToMatrix.R
@@ -7,11 +7,11 @@ test_that("robust", {
         kin0 <- read.table(kin0file, header=TRUE, as.is=TRUE)
         samp <- unique(c(kin$ID1, kin$ID2, kin0$ID1, kin0$ID2))
 
-	KINGmat <- kingToMatrix(c(kinfile, kin0file), verbose=FALSE)
+	KINGmat <- kingToMatrix(c(kinfile, kin0file), estimator="Kinship", verbose=FALSE)
         expect_true(setequal(rownames(KINGmat), samp))
 
         samp.include <- sample(samp, 100)
-	KINGmat <- kingToMatrix(c(kinfile, kin0file), sample.include=samp.include, verbose=FALSE)
+	KINGmat <- kingToMatrix(c(kinfile, kin0file), estimator="Kinship", sample.include=samp.include, verbose=FALSE)
         expect_true(setequal(rownames(KINGmat), samp.include))
 })
 
@@ -28,10 +28,10 @@ test_that("threshold", {
 	kinfile <- system.file("extdata", "MXL_ASW.kin", package="GENESIS")
 	kin0file <- system.file("extdata", "MXL_ASW.kin0", package="GENESIS")
         kin <- read.table(kinfile, header=TRUE, as.is=TRUE)
-	KINGmat <- kingToMatrix(c(kinfile, kin0file), verbose=FALSE)
+	KINGmat <- kingToMatrix(c(kinfile, kin0file), estimator="Kinship", verbose=FALSE)
         rels <- sum(KINGmat > 0)
         
-	KINGmat <- kingToMatrix(c(kinfile, kin0file), thresh=0.02, verbose=FALSE)
+	KINGmat <- kingToMatrix(c(kinfile, kin0file), estimator="Kinship", thresh=0.02, verbose=FALSE)
         rels2 <- sum(KINGmat > 0)
         expect_true(rels2 < rels)
 })
@@ -42,4 +42,13 @@ test_that("snprelate", {
     KINGmat <- kingToMatrix(ibd, verbose=FALSE)
     expect_true(setequal(rownames(KINGmat), ibd$sample.id))
     seqClose(gds)
+})
+
+test_that("wrong column requested", {
+    kinfile <- system.file("extdata", "MXL_ASW.kin", package="GENESIS")
+    kin0file <- system.file("extdata", "MXL_ASW.kin0", package="GENESIS")
+    expect_error(kingToMatrix(c(kinfile, kin0file), verbose=FALSE), "Column PropIBD requested")
+
+    kinfile <- system.file("extdata", "HapMap.seg", package="GENESIS")
+    expect_error(kingToMatrix(c(kinfile, kin0file), estimator="Kinship", verbose=FALSE), "Column Kinship requested")
 })

--- a/vignettes/pcair.Rmd
+++ b/vignettes/pcair.Rmd
@@ -129,7 +129,8 @@ The relevant output from the KING software is two text files with the file exten
 library(GENESIS)
 KINGmat <- kingToMatrix(
     c(system.file("extdata", "MXL_ASW.kin0", package="GENESIS"),
-      system.file("extdata", "MXL_ASW.kin", package="GENESIS")))
+      system.file("extdata", "MXL_ASW.kin", package="GENESIS")),
+      estimator = "Kinship")
 KINGmat[1:5,1:5]
 ```
 


### PR DESCRIPTION
The function used to infer if it was --ibdseg or --kinship output from the column names present. However, with the --related option in KING now, that output contains both. The simplest solution is just to make the user specify which they want (they should know anyways), so I added a new 'estimator' argument. 

I'm not 100% sure I did the match.arg() thing correctly, so if you could at least check that over, that would be good. Thanks!