### PR TITLE
update to makeSparseMatrix to work on large matrices

### DIFF
--- a/R/makeSparseMatrix.R
+++ b/R/makeSparseMatrix.R
@@ -36,6 +36,18 @@ setMethod("makeSparseMatrix",
         stop("thresh must be specified when x is a matrix object")
     }
 
+    # check for names
+    if(is.null(colnames(x))) {
+        if(is.null(rownames(x))) {
+            stop("dimnames must be provided for matrix x to track sample order in the output matrix.")
+        } else {
+            colnames(x) <- rownames(x)
+        }
+    }
+    if(is.null(rownames(x))) {
+        rownames(x) <- colnames(x)
+    }
+    
     # check that matrix is square
     if(!all(rownames(x) == colnames(x))){
         stop("x must be square when it is a matrix object")
@@ -45,10 +57,10 @@ setMethod("makeSparseMatrix",
     if(!is.null(sample.include)){
         # subset to samples in sample.include
         if(verbose) message('Using ', length(sample.include), ' samples in sample.include')
-        x <- x[rownames(x) %in% sample.include & colnames(x) %in% sample.include]
+        x <- x[rownames(x) %in% sample.include, colnames(x) %in% sample.include]
     }else{
         # get list of all samples in the data
-        sample.include <- sort(unique(c(rownames(x), colnames(x))))
+        sample.include <- sort(rownames(x))
         if(verbose) message("Using ", length(sample.include), " samples provided")
     }
 

--- a/R/makeSparseMatrix.R
+++ b/R/makeSparseMatrix.R
@@ -54,7 +54,7 @@ setMethod("makeSparseMatrix",
 
     # check for diag values
     if(is.null(diag.value)){
-        if(any(is.na(diag(x))) stop('When `diag.value` is NULL, diagonal values must be provided for all samples')
+        if(any(is.na(diag(x)))) stop('When `diag.value` is NULL, diagonal values must be provided for all samples')
     }
 
     # get the table of all related pairs

--- a/R/makeSparseMatrix.R
+++ b/R/makeSparseMatrix.R
@@ -2,35 +2,120 @@ setGeneric("makeSparseMatrix", function(x, ...) standardGeneric("makeSparseMatri
 
 setMethod("makeSparseMatrix",
           "matrix",
-          function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
-          	# melt to a data.table
-          	x <- meltMatrix(x = x, drop.lower = TRUE, drop.diag = !is.null(diag.value))
-          	.makeSparseMatrix(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
+          function(x, thresh = NULL, sample.include = NULL, verbose = TRUE){
+            .makeSparseMatrix_matrix(x = x, thresh = thresh, sample.include = sample.include, verbose = verbose)
           })
 
 setMethod("makeSparseMatrix",
           "Matrix",
-          function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
-          	# melt to a data.table
-          	x <- meltMatrix(x = x, drop.lower = TRUE, drop.diag = !is.null(diag.value))
-          	.makeSparseMatrix(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
+          function(x, thresh = NULL, sample.include = NULL, verbose = TRUE){
+          	.makeSparseMatrix_matrix(x = x, thresh = thresh, sample.include = sample.include, verbose = verbose)
           })
 
 setMethod("makeSparseMatrix",
           "data.frame",
           function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
-          	.makeSparseMatrix(x = as.data.table(x), thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
+          	.makeSparseMatrix_df(x = as.data.table(x), thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
           })
 
 setMethod("makeSparseMatrix",
           "data.table",
           function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
-            .makeSparseMatrix(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
+            .makeSparseMatrix_df(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
           })
 
 
+.makeSparseMatrix_matrix <- function(x, thresh = NULL, sample.include = NULL, verbose = TRUE){
 
-.makeSparseMatrix <- function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
+    # keep R CMD check from warning about undefined global variables
+    ID1 <- ID2 <- NULL
+    `.` <- function(...) NULL
+
+    # check that thresh is not NULL
+    if(is.null(thresh)){
+        stop("thresh must be specified when x is a matrix object")
+    }
+
+    # check that matrix is square
+    if(!all(rownames(x) == colnames(x))){
+        stop("x must be square when it is a matrix object")
+    }
+
+    # check sample.include
+    if(!is.null(sample.include)){
+        # subset to samples in sample.include
+        if(verbose) message('Using ', length(sample.include), ' samples in sample.include')
+        x <- x[rownames(x) %in% sample.include & colnames(x) %in% sample.include]
+    }else{
+        # get list of all samples in the data
+        sample.include <- sort(unique(c(rownames(x), colnames(x))))
+        if(verbose) message("Using ", length(sample.include), " samples provided")
+    }
+
+    # get the table of all related pairs
+    rel <- apply(x, MARGIN = 1, FUN = function(v){ names(v)[v > thresh & !is.na(v)] })
+    rel <- lapply(seq_along(rel), function(i) { data.table('ID1' = names(rel)[[i]], 'ID2' = rel[[i]]) })
+    rel <- do.call(rbind, rel)
+    rel <- rel[,`:=`(ID1 = as.character(ID1), ID2 = as.character(ID2))]
+    setkeyv(rel, c('ID1', 'ID2'))
+
+    # create graph of relatives
+    if(verbose) message("Identifying clusters of relatives...")
+    g <- igraph::graph_from_data_frame(rel[ID1 != ID2])
+    # extract cluster membership
+    clu <- igraph::components(g)
+    mem <- clu$membership
+    
+    blocks <- list()
+    block.id <- list()
+    if(clu$no > 0){
+        if(verbose) message("    ", length(mem), " relatives in ", clu$no, " clusters; largest cluster = ", max(clu$csize))
+        if(verbose) message("Creating block matrices for clusters...")
+        for(i in 1:clu$no){
+            # samples in the cluster
+            ids <- names(mem[mem == i])
+            
+            # extract the matrix for all pairs in the cluster
+            submat <- x[rownames(x) %in% ids, colnames(x) %in% ids]
+            
+            # store in the list
+            blocks[[i]] <- submat
+            block.id[[i]] <- rownames(submat)
+        }
+    }else{
+        if(verbose) message("    No clusters identified")
+    }
+        
+    # add in identity matrix of unrelated samples
+    unrel.id <- setdiff(sample.include, names(mem))
+    if(verbose) message(length(unrel.id), " samples with no relatives included")
+
+    if(length(unrel.id) > 0) {
+        # data for the diagonal
+        ddat <- diag(x)[rownames(x) %in% unrel.id]
+        blocks[[clu$no + 1]] <- Diagonal(n = length(ddat), x = ddat)
+        block.id[[clu$no + 1]] <- names(ddat)
+    }
+
+    # create block diagonal matrix
+    if(length(blocks) > 1){
+        if(verbose) message("Putting all samples together into one block diagonal matrix")
+        mat_sparse <- bdiag(blocks)
+    }else{
+        mat_sparse <- Matrix(blocks[[1]])
+    } 
+    
+    # ids of samples
+    mat.id <- unlist(block.id)
+    rownames(mat_sparse) <- mat.id
+    colnames(mat_sparse) <- mat.id
+
+    # set the matrix to symmetric to save memory
+    mat_sparse <- as(mat_sparse, "symmetricMatrix")
+    return(mat_sparse)
+}
+
+.makeSparseMatrix_df <- function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
 
     # keep R CMD check from warning about undefined global variables
     ID1 <- ID2 <- value <- NULL
@@ -132,37 +217,6 @@ setMethod("makeSparseMatrix",
     return(mat_sparse)
 }
 
-
-
-setGeneric("meltMatrix", function(x, ...) standardGeneric("meltMatrix"))
-
-setMethod("meltMatrix",
-          "matrix",
-          function(x, drop.lower = FALSE, drop.diag = FALSE){
-            ID1 <- ID2 <- NULL
-            if(drop.lower){
-                x[lower.tri(x, diag = drop.diag)] <- NA
-            }
-            x <- as.data.table(reshape2::melt(x, varnames = c('ID1', 'ID2'), na.rm = TRUE, as.is = TRUE))
-            x <- x[,`:=`(ID1 = as.character(ID1), ID2 = as.character(ID2))]
-            setkeyv(x, c('ID1', 'ID2'))
-          })
-
-setMethod("meltMatrix",
-          "Matrix",
-          function(x, drop.lower = FALSE, drop.diag = FALSE){
-            if(drop.lower){
-                x[lower.tri(x, diag = drop.diag)] <- NA
-            }
-
-            # this modeled after reshape2:::melt.matrix
-            labels <- as.data.table(expand.grid(dimnames(x), KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE))
-            setnames(labels, c('Var1', 'Var2'), c('ID1', 'ID2'))
-
-            missing <- is.na(as.vector(x))
-            x <- cbind(labels[!missing,], data.table(value = x[!missing])) 
-            setkeyv(x, c('ID1', 'ID2'))
-          })
 
 
 

--- a/R/makeSparseMatrix.R
+++ b/R/makeSparseMatrix.R
@@ -2,13 +2,13 @@ setGeneric("makeSparseMatrix", function(x, ...) standardGeneric("makeSparseMatri
 
 setMethod("makeSparseMatrix",
           "matrix",
-          function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
+          function(x, thresh = 2^(-11/2), sample.include = NULL, diag.value = NULL, verbose = TRUE){
             .makeSparseMatrix_matrix(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
           })
 
 setMethod("makeSparseMatrix",
           "Matrix",
-          function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
+          function(x, thresh = 2^(-11/2), sample.include = NULL, diag.value = NULL, verbose = TRUE){
           	.makeSparseMatrix_matrix(x = x, thresh = thresh, sample.include = sample.include, diag.value = diag.value, verbose = verbose)
           })
 
@@ -25,7 +25,7 @@ setMethod("makeSparseMatrix",
           })
 
 
-.makeSparseMatrix_matrix <- function(x, thresh = NULL, sample.include = NULL, diag.value = NULL, verbose = TRUE){
+.makeSparseMatrix_matrix <- function(x, thresh = 2^(-11/2), sample.include = NULL, diag.value = NULL, verbose = TRUE){
 
     # keep R CMD check from warning about undefined global variables
     ID1 <- ID2 <- NULL
@@ -299,7 +299,7 @@ setMethod("kingToMatrix",
 setOldClass("snpgdsIBDClass")
 setMethod("kingToMatrix",
           "snpgdsIBDClass",
-          function(king, sample.include = NULL, thresh = NULL, verbose = TRUE) {
+          function(king, sample.include = NULL, thresh = 2^(-11/2), verbose = TRUE) {
               ID <- king$sample.id
               king <- king$kinship
               dimnames(king) <- list(ID, ID)

--- a/R/pcrelate.R
+++ b/R/pcrelate.R
@@ -651,6 +651,35 @@ correctK0 <- function(kinBtwn){
 }
 
 
+setGeneric("meltMatrix", function(x, ...) standardGeneric("meltMatrix"))
+
+setMethod("meltMatrix",
+          "matrix",
+          function(x, drop.lower = FALSE, drop.diag = FALSE){
+            ID1 <- ID2 <- NULL
+            if(drop.lower){
+                x[lower.tri(x, diag = drop.diag)] <- NA
+            }
+            x <- as.data.table(reshape2::melt(x, varnames = c('ID1', 'ID2'), na.rm = TRUE, as.is = TRUE))
+            x <- x[,`:=`(ID1 = as.character(ID1), ID2 = as.character(ID2))]
+            setkeyv(x, c('ID1', 'ID2'))
+          })
+
+setMethod("meltMatrix",
+          "Matrix",
+          function(x, drop.lower = FALSE, drop.diag = FALSE){
+            if(drop.lower){
+                x[lower.tri(x, diag = drop.diag)] <- NA
+            }
+
+            # this modeled after reshape2:::melt.matrix
+            labels <- as.data.table(expand.grid(dimnames(x), KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE))
+            setnames(labels, c('Var1', 'Var2'), c('ID1', 'ID2'))
+
+            missing <- is.na(as.vector(x))
+            x <- cbind(labels[!missing,], data.table(value = x[!missing])) 
+            setkeyv(x, c('ID1', 'ID2'))
+          })
 
 
 

--- a/man/kingToMatrix.Rd
+++ b/man/kingToMatrix.Rd
@@ -6,7 +6,7 @@
 \description{\code{kingToMatrix} is used to extract the pairwise kinship coefficient estimates from the output text files of KING --ibdseg, KING --kinship, or KING --related and put them into an R object of class \code{Matrix}. One use of this matrix is that it can be read by the functions \code{\link{pcair}} and \code{\link{pcairPartition}}.}
 \usage{
 \S4method{kingToMatrix}{character}(king, estimator = c("PropIBD", "Kinship"), sample.include = NULL, thresh = NULL, verbose = TRUE)
-\S4method{kingToMatrix}{snpgdsIBDClass}(king, sample.include = NULL, thresh = NULL, verbose = TRUE)
+\S4method{kingToMatrix}{snpgdsIBDClass}(king, sample.include = NULL, thresh = 2^(-11/2), verbose = TRUE)
 }
 \arguments{
   \item{king}{Output from KING, either a \code{snpgdsIBDClass} object from \code{\link{snpgdsIBDKING}} or a character vector of one or more file names output from the command-line version of KING; see 'Details'.}

--- a/man/makeSparseMatrix.Rd
+++ b/man/makeSparseMatrix.Rd
@@ -12,9 +12,9 @@
                  verbose = TRUE)
 \S4method{makeSparseMatrix}{data.frame}(x, thresh = NULL, sample.include = NULL, diag.value = NULL, 
                  verbose = TRUE)
-\S4method{makeSparseMatrix}{matrix}(x, thresh = NULL, sample.include = NULL, diag.value = NULL, 
+\S4method{makeSparseMatrix}{matrix}(x, thresh = 2^(-11/2), sample.include = NULL, diag.value = NULL, 
                  verbose = TRUE)
-\S4method{makeSparseMatrix}{Matrix}(x, thresh = NULL, sample.include = NULL, diag.value = NULL, 
+\S4method{makeSparseMatrix}{Matrix}(x, thresh = 2^(-11/2), sample.include = NULL, diag.value = NULL, 
                  verbose = TRUE)
 }
 \arguments{

--- a/tests/testthat/test_makeSparseMatrix.R
+++ b/tests/testthat/test_makeSparseMatrix.R
@@ -2,7 +2,9 @@ context("makeSparseMatrix tests")
 
 test_that("no clusters", {
     x <- diag(x=1:10)
-    sm <- makeSparseMatrix(x, verbose=FALSE)
+    expect_error(makeSparseMatrix(x, thresh=0.5, verbose=FALSE), "dimnames")
+    colnames(x) <- 1:10
+    sm <- makeSparseMatrix(x, thresh=0.5, verbose=FALSE)
     expect_true(is(sm, "sparseMatrix"))
     expect_true(isDiagonal(sm))
     expect_true(setequal(diag(x), diag(sm)))
@@ -10,9 +12,18 @@ test_that("no clusters", {
 
 test_that("two clusters", {
     x <- diag(nrow=10, ncol=10)
+    rownames(x) <- 1:10
     x[2:4,2:4] <- 0.5
     x[7:9,7:9] <- 0.5
     diag(x) <- 1
-    sm <- makeSparseMatrix(x)
+    expect_message(sm <- makeSparseMatrix(x, thresh=0), "2 clusters")
     expect_true(is(sm, "sparseMatrix"))
+})
+
+test_that("sample include", {
+    x <- diag(x=1:10)
+    dimnames(x) <- list(1:10,1:10)
+    sm <- makeSparseMatrix(x, sample.include=2:6, thresh=0, verbose=FALSE)
+    expect_equal(dimnames(sm), list(as.character(2:6), as.character(2:6)))
+    expect_equal(diag(sm), 2:6)
 })


### PR DESCRIPTION
In trying to make the sparse matrix for freeze 5, I discovered that makeSparseMatrix didn't work on matrices with > 2^31 elements.... 🤦‍♂ 

I came up with a different way to do this. As a result, matrix/Matrix objects are now handled differently than data.frame/data.table objects. The function .makeSparseMatrix_df is the same as what .makeSparseMatrix used to be. The new function .makeSparseMatrix_matrix is a modified version of that function to work matrix (or Matrix) objects. These are all still called as methods for makeSparseMatrix. If you want to do this a different way, that's fine with me. I tested the new function on the fr5 KM, and it seems to work. 

I moved meltMatrix to the pcrelate file simply because it's only used there now.