### PR TITLE
Fix issue when a starting VC is 0, or small

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
 Version: 2.17.1
-Date: 2019-10-23
+Date: 2020-01-13
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Ken Rice, Tamar Sofer, Timothy Thornton, Chaoyu Yu
 Maintainer: Stephanie M. Gogarten <sdmorris@uw.edu>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.17.0
+Version: 2.17.1
 Date: 2019-10-23
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Ken Rice, Tamar Sofer, Timothy Thornton, Chaoyu Yu

--- a/R/runAIREMLgaussian.R
+++ b/R/runAIREMLgaussian.R
@@ -11,6 +11,7 @@
         sigma2.k <- rep((1/(m+1))*sigma2.p, (m+g))
     }else{
         sigma2.k <- as.vector(start)
+        sigma2.k[sigma2.k < 2*AIREML.tol] <- 2*AIREML.tol # starting values that are too small are slightly increased
     }
     sigma2.kplus1 <- rep(NA, length(sigma2.k))
     zeroFLAG <- rep(FALSE, length(sigma2.k))

--- a/R/runAIREMLother.R
+++ b/R/runAIREMLother.R
@@ -9,6 +9,7 @@
         sigma2.k <- rep(sqrt(AIREML.tol), m)
     }else{
         sigma2.k <- as.vector(start)
+        sigma2.k[sigma2.k < 2*AIREML.tol] <- 2*AIREML.tol # starting values that are too small are slightly increased
     }
     sigma2.kplus1 <- rep(NA, length(sigma2.k))
     zeroFLAG <- rep(FALSE, length(sigma2.k))


### PR DESCRIPTION
When the starting value for a VC is < AIREML.tol, set its starting value to 2*AIREML.tol. This prevents a bug where zeroFLAG is not set correctly, causing the VCs to not update at all. This also gives the VC an opportunity to not be 0; it can return to 0 with zeroFLAG correctly marked in one iteration if that is the best fit. 