### PR TITLE
Force design matrices to be non-sparse

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,3 @@
+^renv$
+^renv\.lock$
 ^\.travis\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,12 @@
 *.html
 *.so
 *.o
+
+# renv for development
+.Rprofile
+renv.lock
+renv/
+
+# other
+*.Rproj
+.Rproj.user/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.19.0
+Version: 2.19.1
 Date: 2020-04-22
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Ken Rice, Tamar Sofer, Timothy Thornton, Chaoyu Yu
@@ -11,22 +11,22 @@ Maintainer: Stephanie M. Gogarten <sdmorris@uw.edu>
 Description: The GENESIS package provides methodology for estimating,
         inferring, and accounting for population and pedigree structure
         in genetic analyses.  The current implementation provides
-        functions to perform PC-AiR (Conomos et al., 2015, Gen Epi) and PC-Relate 
-        (Conomos et al., 2016, AJHG). PC-AiR performs a Principal Components 
-        Analysis on genome-wide SNP data for the detection of population 
-        structure in a sample that may contain known or cryptic relatedness. 
-        Unlike standard PCA, PC-AiR accounts for relatedness in the sample 
-        to provide accurate ancestry inference that is not confounded by 
-        family structure. PC-Relate uses ancestry representative principal 
-        components to adjust for population structure/ancestry and accurately 
-        estimate measures of recent genetic relatedness such as kinship 
-        coefficients, IBD sharing probabilities, and inbreeding coefficients. 
-        Additionally, functions are provided to perform efficient variance 
-        component estimation and mixed model association testing for both 
+        functions to perform PC-AiR (Conomos et al., 2015, Gen Epi) and PC-Relate
+        (Conomos et al., 2016, AJHG). PC-AiR performs a Principal Components
+        Analysis on genome-wide SNP data for the detection of population
+        structure in a sample that may contain known or cryptic relatedness.
+        Unlike standard PCA, PC-AiR accounts for relatedness in the sample
+        to provide accurate ancestry inference that is not confounded by
+        family structure. PC-Relate uses ancestry representative principal
+        components to adjust for population structure/ancestry and accurately
+        estimate measures of recent genetic relatedness such as kinship
+        coefficients, IBD sharing probabilities, and inbreeding coefficients.
+        Additionally, functions are provided to perform efficient variance
+        component estimation and mixed model association testing for both
         quantitative and binary phenotypes.
 License: GPL-3
 URL: https://github.com/UW-GAC/GENESIS
-Depends: 
+Depends:
 Imports: Biobase, BiocGenerics, GWASTools, gdsfmt, GenomicRanges, IRanges, S4Vectors, SeqArray, SeqVarTools, SNPRelate,
 	 data.table, dplyr, foreach, graphics, grDevices, igraph, Matrix, methods, reshape2, stats, utils
 Suggests: CompQuadForm, poibin, SPAtest, survey,

--- a/R/calcLQ.R
+++ b/R/calcLQ.R
@@ -1,9 +1,9 @@
 .calcLikelihoodQuantities <- function(Y, X, Sigma.inv, cholSigma.diag){
 
-    if (is(Sigma.inv, "Matrix")) X <- Matrix(X)
+    if (is(Sigma.inv, "Matrix")) X <- Matrix(X, sparse = FALSE)
     n <- length(Y)
     k <- ncol(X)
-    
+
     ### Calulate the generalized least squares estimate
     Sigma.inv_X <- crossprod(Sigma.inv, X)
     Xt_Sigma.inv_X <- crossprod(X, Sigma.inv_X)
@@ -12,7 +12,7 @@
     chol.Xt_Sigma.inv_X <- chol(Xt_Sigma.inv_X)
     Xt_Sigma.inv_X.inv <- chol2inv(chol.Xt_Sigma.inv_X)
     beta <- crossprod(Xt_Sigma.inv_X.inv, crossprod(Sigma.inv_X, Y))
-    
+
     # calc Xb
     fits <- X %*% beta
     # calc marginal residuals = (Y - Xb)
@@ -20,22 +20,22 @@
 
     ### calculate PY
     PY <- crossprod(Sigma.inv, residM)
-    
+
     # compute RSS
     YPY <- crossprod(Y, PY)
     RSS <- as.numeric(YPY/(n-k))
     # Sigma.inv_R <- crossprod(Sigma.inv, residM)
     # Rt_Sigma.inv_R <- crossprod(residM, Sigma.inv_R)
     # Rt_Sigma.inv_R <- crossprod(residM, PY)
-    # RSS <- as.numeric(Rt_Sigma.inv_R/(n - k)) 
+    # RSS <- as.numeric(Rt_Sigma.inv_R/(n - k))
 
     # log likelihood
     logLik <- as.numeric(-0.5 * n * log(2 * pi * RSS) - sum(log(cholSigma.diag)) - 0.5 * YPY/RSS)
-    # REML log likelihood; accounting for estimation of mean effects 
+    # REML log likelihood; accounting for estimation of mean effects
     logLikR <- as.numeric(logLik + 0.5 * k * log(2 * pi * RSS) - sum(log(diag(chol.Xt_Sigma.inv_X))))
 
-    return(list(PY = PY, RSS = RSS, logLik = logLik, logLikR = logLikR, 
-                Sigma.inv_X = Sigma.inv_X, Xt_Sigma.inv_X.inv = Xt_Sigma.inv_X.inv, 
+    return(list(PY = PY, RSS = RSS, logLik = logLik, logLikR = logLikR,
+                Sigma.inv_X = Sigma.inv_X, Xt_Sigma.inv_X.inv = Xt_Sigma.inv_X.inv,
                 beta = as.numeric(beta), fits = fits, residM = residM))
-    
+
 }

--- a/R/nullModelTestPrep.R
+++ b/R/nullModelTestPrep.R
@@ -1,12 +1,12 @@
 
 ## takes a null model and prepare specific arguments to streamline the testing
-nullModelTestPrep <- function(nullmod){ 
+nullModelTestPrep <- function(nullmod){
     Y <- nullmod$workingY
     X <- nullmod$model.matrix
     C <- nullmod$cholSigmaInv
 
     if (length(C) > 1) { ## n by n cholSigmaInv (may be Diagonal)
-        if (is(C, "Matrix")) X <- Matrix(X)
+        if (is(C, "Matrix")) X <- Matrix(X, sparse = FALSE)
         CX <- crossprod(C, X)
         CXCXI <- tcrossprod(CX, chol2inv(chol(crossprod(CX))))
         # qrmod <- base::qr(CX)
@@ -15,7 +15,7 @@ nullModelTestPrep <- function(nullmod){
         Ytilde <- CY - tcrossprod(CXCXI, crossprod(CY, CX))
         resid <- C %*% Ytilde
         # resid <- tcrossprod(C, crossprod(nullmod$resid.marginal, C))
-        
+
     } else { ## cholSigmaInv is a scalar
         CX <- C*X
         CXCXI <- tcrossprod(CX, chol2inv(chol(crossprod(CX))))
@@ -63,7 +63,7 @@ calcGtilde <- function(nullmod, G){
         }
         Gtilde <- do.call(cbind, Gtilde)
     }
-    
+
     return(Gtilde)
 }
 

--- a/R/prepareOutputForNullModel.R
+++ b/R/prepareOutputForNullModel.R
@@ -2,7 +2,7 @@
 ### preparing output arguments for regression models that are not mixed.
 .nullModOutReg <- function(y, X, mod, family, group.idx = NULL){
     family$mixedmodel <- FALSE
-    
+
     if (family$family == "gaussian"){
         varComp <- summary(mod)$sigma^2
         cholSigmaInv <- sqrt(1/varComp)
@@ -13,11 +13,11 @@
         cholSigmaInv <- Diagonal(x=sqrt(vmu))
         workingY <- .calcWorkingYnonGaussian(y, eta = mod$linear.predictors, family)$Y
     }
-    
+
     varCompCov <- NULL
-    hetResid <- FALSE 
+    hetResid <- FALSE
     fixef <- as.data.frame(summary(mod)$coef)
-    varNames <- colnames(X) 
+    varNames <- colnames(X)
     rownames(fixef) <- varNames
     betaCov <- vcov(mod, complete=FALSE)
     dimnames(betaCov) <- list(varNames, varNames)
@@ -28,12 +28,12 @@
     converged <- ifelse(family$family == "gaussian", TRUE, mod$converged)
     zeroFLAG <- NULL
     RSS <- ifelse(family$family == "gaussian", sum(resid.marginal^2)/varComp/(nrow(X) - ncol(X)), 1)
-    
+
     out <- list(family = family, hetResid = hetResid, varComp = varComp,
-                varCompCov = varCompCov, fixef = fixef, betaCov = betaCov, 
-                fitted.values = fitted.values, resid.marginal = resid.marginal, 
-                logLik = logLik, AIC = AIC, workingY = workingY, outcome = y, 
-                model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv, 
+                varCompCov = varCompCov, fixef = fixef, betaCov = betaCov,
+                fitted.values = fitted.values, resid.marginal = resid.marginal,
+                logLik = logLik, AIC = AIC, workingY = workingY, outcome = y,
+                model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv,
                 converged = converged, zeroFLAG = zeroFLAG, RSS = RSS)
     class(out) <- "GENESIS.nullModel"
     return(out)
@@ -43,55 +43,55 @@
 
 .nullModOutWLS <- function(y, X, vc.mod, family, group.idx = NULL){
     family$mixedmodel <- FALSE
-    
+
     if (is.null(names(group.idx))){
         group.names <- paste0("G", seq_along(group.idx))
     } else { # there are names
         group.names <- names(group.idx)
     }
-    
+
     varComp <- vc.mod$varComp
     names(varComp) <- group.names
     varCompCov <- solve(vc.mod$AI)
     dimnames(varCompCov) <- list(group.names, group.names)
-    
+
     hetResid <- TRUE
-    varNames <- colnames(X) 
+    varNames <- colnames(X)
     ## cholSigmaInv <- Diagonal(x=sqrt(diag(vc.mod$Sigma.inv)))
     cholSigmaInv.diag <- sqrt(diag(vc.mod$Sigma.inv))
     cholSigmaInv <- Diagonal(x=cholSigmaInv.diag)
-    
+
     RSS <- vc.mod$RSS
-   
+
     ## betaCov <- as.matrix(RSS * chol2inv(chol(crossprod(crossprod(cholSigmaInv, X)))))
     betaCov <- as.matrix(RSS * chol2inv(chol(crossprod(cholSigmaInv.diag*X))))
     dimnames(betaCov) <- list(varNames, varNames)
-    
+
     SE <- sqrt(diag(betaCov))
     Stat <- (vc.mod$beta/SE)^2
     pval <- pchisq(Stat, df = 1, lower.tail = FALSE)
 
     fixef <- data.frame(Est = vc.mod$beta, SE = SE, Stat = Stat, pval = pval)
     rownames(fixef) <- varNames
-    
+
     fitted.values <- as.vector(vc.mod$fits)
     resid.marginal <-  vc.mod$residM
     logLik <- vc.mod$logLik
     logLikR <- vc.mod$logLikR
     AIC <- 2 * (ncol(X) + length(varComp)) - 2 * logLik
-    
+
     workingY <- drop(y)
-    
+
     resid.conditional <- workingY - drop(vc.mod$eta) ### should be the same as resid.marginal
-    
+
     converged <- TRUE
     zeroFLAG <- NULL
 
-    out <- list(family = family, hetResid = hetResid, varComp = varComp, varCompCov = varCompCov, 
-                fixef = fixef, betaCov = betaCov, fitted.values = fitted.values, 
-                resid.marginal = resid.marginal, resid.conditional = resid.conditional, 
-                logLik = logLik, logLikR  = logLikR, AIC = AIC, workingY = workingY, 
-                outcome = y, model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv, 
+    out <- list(family = family, hetResid = hetResid, varComp = varComp, varCompCov = varCompCov,
+                fixef = fixef, betaCov = betaCov, fitted.values = fitted.values,
+                resid.marginal = resid.marginal, resid.conditional = resid.conditional,
+                logLik = logLik, logLikR  = logLikR, AIC = AIC, workingY = workingY,
+                outcome = y, model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv,
                 converged = converged, zeroFLAG = zeroFLAG, niter = vc.mod$niter, RSS = RSS)
     class(out) <- "GENESIS.nullModel"
     return(out)
@@ -102,7 +102,7 @@
 .nullModOutMM <- function(y, workingY, X, vc.mod, family, covMatList, group.idx = NULL, vmu = NULL, gmuinv = NULL, drop.zeros = TRUE){
     n <- nrow(X)
     m <- length(covMatList)
-    
+
     if (!is.null(group.idx)){
         g <- length(group.idx)
         if (is.null(names(group.idx))){
@@ -115,79 +115,79 @@
         if (family$family == "gaussian"){
             group.idx <- list(E = 1:n)
             g <- 1
-            group.names <- "E" 
+            group.names <- "E"
         } else{
             g <- 0
             group.names <- NULL
         }
     }
-    
+
     if(is.null(names(covMatList))){
         names(covMatList) <- paste0("M",1:m)
     }
 
     matrix.names <- names(covMatList)
-    
+
     family$mixedmodel <- TRUE
     varComp <- vc.mod$varComp
     hetResid <- (length(group.idx) > 1)
 
-    
+
     names(varComp) <- paste("V_",c(names(covMatList),group.names),sep="")
     varCompCov <- matrix(NA, nrow=(m+g), ncol=(m+g))
     colnames(varCompCov) <- paste("V_",c(names(covMatList),group.names),sep="")
     rownames(varCompCov) <- paste("V_",c(names(covMatList),group.names),sep="")
 
-    
+
     if(drop.zeros){
         varCompCov[!vc.mod$zeroFLAG, !vc.mod$zeroFLAG] <- solve(vc.mod$AI)
     }else{
         varCompCov <- solve(vc.mod$AI)
     }
-    
+
     # Cholesky Decomposition of Sigma.inv
     cholSigmaInv <- t(chol(vc.mod$Sigma.inv))
     dimnames(cholSigmaInv) <- list(colnames(covMatList[[1]]), colnames(covMatList[[1]]))
-    
 
-    varNames <- colnames(X) 
-    
+
+    varNames <- colnames(X)
+
     RSS <- ifelse(family$family == "gaussian", vc.mod$RSS, 1)
 
-    X.tmp <- if (is(cholSigmaInv, "Matrix")) Matrix(X) else X
+    X.tmp <- if (is(cholSigmaInv, "Matrix")) Matrix(X, sparse = FALSE) else X
     betaCov <- as.matrix(RSS * chol2inv(chol(crossprod(crossprod(cholSigmaInv, X.tmp)))))
     rm(X.tmp)
     #betaCov <- as.matrix(RSS * chol2inv(chol(crossprod(crossprod(cholSigmaInv, X)))))
 
     dimnames(betaCov) <- list(varNames, varNames)
-    
+
     SE <- sqrt(diag(betaCov))
     Stat <- (vc.mod$beta/SE)^2
     pval <- pchisq(Stat, df = 1, lower.tail = FALSE)
 
     fixef <- data.frame(Est = vc.mod$beta, SE = SE, Stat = Stat, pval = pval)
     rownames(fixef) <- varNames
-    
+
     fitted.values <- as.vector(vc.mod$fits)
     resid.marginal <-  vc.mod$residM
     logLik <- vc.mod$logLik
     logLikR <- vc.mod$logLikR
     AIC <- 2 * (ncol(X) + length(varComp)) - 2 * logLik
-    
+
     workingY <- drop(workingY)
-    
+
     resid.conditional <- workingY - drop(vc.mod$eta)
-    
+
     converged <- vc.mod$converged
     zeroFLAG <- vc.mod$zeroFLAG
     niter <- vc.mod$niter
 
-    out <- list(family = family, hetResid = hetResid, varComp = varComp, 
-                varCompCov = varCompCov, fixef = fixef, betaCov = betaCov, 
-                fitted.values = fitted.values, resid.marginal =resid.marginal, 
-                resid.conditional = resid.conditional, logLik = logLik, 
+    out <- list(family = family, hetResid = hetResid, varComp = varComp,
+                varCompCov = varCompCov, fixef = fixef, betaCov = betaCov,
+                fitted.values = fitted.values, resid.marginal =resid.marginal,
+                resid.conditional = resid.conditional, logLik = logLik,
                 logLikR = logLikR, AIC = AIC, workingY = workingY, outcome = y,
-                model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv, 
+                model.matrix = X, group.idx = group.idx, cholSigmaInv = cholSigmaInv,
                 converged = converged, zeroFLAG = zeroFLAG, niter = niter, RSS = RSS)
     class(out) <- "GENESIS.nullMixedModel"
     return(out)

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,5 +1,10 @@
 \name{NEWS}
 \title{NEWS for GENESIS}
+\section{Version 2.19.1}{
+    \itemize{
+      \item Force design matrices to be non-sparse.
+    }
+}
 \section{Version 2.17.4}{
     \itemize{
       \item Fix a bug that prevented use of multiple environment variables in GxE.


### PR DESCRIPTION
The Matrix package by default creates a sparse matrix when more than 50% of the values are zero. For sparse matrices with only slightly more than 50% zero values, matrix multiplication is much less efficient. It is possible that a design matrix will have more than 50% zero values (e.g., if a large number of conditional variants are included), and thus be subject to reduced efficiency when fitting the null model, but it is unlikely that they will have enough zero values to make sparse matrix multiplication efficient when fitting the null model. This pull request forces all design matrices created with the Matrix package to be non-sparse and improves efficiency when fitting null models with a lot of conditional variants.