### PR TITLE
Add error with collinear covariates

### DIFF
--- a/R/createDesignMatrix.R
+++ b/R/createDesignMatrix.R
@@ -7,7 +7,7 @@ createDesignMatrix <- function(x, outcome, covars=NULL, group.var=NULL) {
             x[[f]] <- factor(x[[f]])
         }
     }
-    
+
     if (!is.null(covars)) {
         model.formula <- as.formula(paste(outcome, "~", paste(covars, collapse="+")))
         # allow interactions
@@ -17,18 +17,18 @@ createDesignMatrix <- function(x, outcome, covars=NULL, group.var=NULL) {
     }
     x <- x[, unique(c(outcome, covars, group.var)), drop=FALSE]
     x <- x[complete.cases(x),,drop=FALSE]
-    
+
     # group index
     if (!is.null(group.var)) {
         group.idx <- .indexList(x[[group.var]])
     } else {
         group.idx <- NULL
     }
-    
+
     # outcome vector - preserve column name
     #y <- x[[outcome]]
     y <- as.matrix(x[,outcome,drop=FALSE])
-    # create design matrix    
+    # create design matrix
     X <- model.matrix(model.formula, data=x)
     # check for columns of all the same value (except the intercept)
     dropcol <- append(FALSE, apply(X[,-1,drop=FALSE], 2, var) == 0)
@@ -37,6 +37,12 @@ createDesignMatrix <- function(x, outcome, covars=NULL, group.var=NULL) {
         X <- X[,!dropcol,drop=FALSE]
     }
 
+    # Check that design matrix is not collinear.
+    rank <- Matrix::rankMatrix(X)
+    if (rank < ncol(X)) {
+      err <- "Design matrix is not full rank; are some covariates collinear?"
+      stop(err)
+    }
     list(y=y, X=X, group.idx=group.idx)
 }
 

--- a/R/createDesignMatrix.R
+++ b/R/createDesignMatrix.R
@@ -40,7 +40,7 @@ createDesignMatrix <- function(x, outcome, covars=NULL, group.var=NULL) {
     # Check that design matrix is not collinear.
     rank <- Matrix::rankMatrix(X)
     if (rank < ncol(X)) {
-      err <- "Design matrix is not full rank; are some covariates collinear?"
+      err <- "Design matrix is not full rank; the model can not be fit. Check for multicollinearity among your covariates."
       stop(err)
     }
     list(y=y, X=X, group.idx=group.idx)

--- a/man/fitNullModel.Rd
+++ b/man/fitNullModel.Rd
@@ -63,7 +63,7 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
 \details{
     If \code{x} is a data.frame, the rownames of \code{x} must match the row and column names of \code{cov.mat} (if \code{cov.mat} is specified). If \code{x} is an \code{\link{AnnotatedDataFrame}} or other object containing an \code{\link{AnnotatedDataFrame}}, \code{x} will be re-ordered (if necessary) so that \code{sample.id} or \code{scanID} is in the same order as the row and column names of \code{cov.mat}.
 
-    The code checks for multicollinearity of the design matrix by checking that its rank is equal to the number of columns; if the rank is smaller, it fails with an error.
+    The code checks for multicollinearity of covariates by checking that the rank of the design matrix is equal to the number of columns; if the rank is smaller, it fails with an error.
 
     \code{cov.mat} is used to specify the covariance structures of the random effects terms in the model.  For example, to include a polygenic random effect, one matrix in \code{cov.mat} could be a kinship matrix or a genetic relationship matrix (GRM).  As another example, to include household membership as a random effect, one matrix in \code{cov.mat} should be a 0/1 matrix with a 1 in the \code{[i,j]} and \code{[j,i]} entries if individuals \code{i} and \code{j} are in the same household and 0 otherwise; the diagonals of such a matrix should all be 1.
 

--- a/man/fitNullModel.Rd
+++ b/man/fitNullModel.Rd
@@ -25,7 +25,7 @@
 
 \usage{
 \S4method{fitNullModel}{data.frame}(x, outcome, covars = NULL, cov.mat = NULL,
-            group.var = NULL, family = "gaussian", start = NULL, 
+            group.var = NULL, family = "gaussian", start = NULL,
             AIREML.tol = 1e-4, max.iter = 100, EM.iter = 0, drop.zeros = TRUE,
             verbose = TRUE)
 \S4method{fitNullModel}{AnnotatedDataFrame}(x, outcome, covars = NULL, cov.mat = NULL,
@@ -63,19 +63,21 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
 \details{
     If \code{x} is a data.frame, the rownames of \code{x} must match the row and column names of \code{cov.mat} (if \code{cov.mat} is specified). If \code{x} is an \code{\link{AnnotatedDataFrame}} or other object containing an \code{\link{AnnotatedDataFrame}}, \code{x} will be re-ordered (if necessary) so that \code{sample.id} or \code{scanID} is in the same order as the row and column names of \code{cov.mat}.
 
+    The code checks for collinear of the design matrix by checking that its rank is equal to the number of columns; if the rank is smaller, it fails with an error.
+
     \code{cov.mat} is used to specify the covariance structures of the random effects terms in the model.  For example, to include a polygenic random effect, one matrix in \code{cov.mat} could be a kinship matrix or a genetic relationship matrix (GRM).  As another example, to include household membership as a random effect, one matrix in \code{cov.mat} should be a 0/1 matrix with a 1 in the \code{[i,j]} and \code{[j,i]} entries if individuals \code{i} and \code{j} are in the same household and 0 otherwise; the diagonals of such a matrix should all be 1.
-    
+
     When \code{family} is not gaussian, the penalized quasi-likelihood (PQL) approximation to the generalized linear mixed model (GLMM) is fit following the procedure of GMMAT (Chen et al.).
-    
+
     For some outcomes, there may be evidence that different groups of observations have different residual variances, and the standard LMM assumption of homoscedasticity is violated. When \code{group.var} is specified, separate (heterogeneous) residual variance components are fit for each unique value of \code{group.var}.
-    
+
     Let \code{m} be the number of matrices in \code{cov.mat} and let \code{g} be the number of categories in the variable specified by \code{group.var}. The length of the \code{start} vector must be \code{(m + 1)} when \code{family} is gaussian and \code{group.var} is \code{NULL}; \code{(m + g)} when \code{family} is gaussian and \code{group.var} is specified; or m when \code{family} is not gaussian.
-    
+
     A Newton-Raphson iterative procedure with Average Information REML (AIREML) is used to estimate the variance components of the random effects. When the absolute change between all of the new and previous variance component estimates is less than \code{var(outcome)*AIREML.tol}, the algorithm declares convergence of the estimates. Sometimes a variance component may approach the boundary of the parameter space at 0; step-halving is used to prevent any component from becomming negative. However, when a variance component gets near the 0 boundary, the algorithm can sometimes get "stuck", preventing the other variance components from converging; if \code{drop.zeros} is TRUE, then variance components that converge to a value less than \code{AIREML.tol} will be dropped from the model and the estimation procedure will continue with the remaining variance components.
 
     After inverse-normal transformation, the variance rescaling is done with the same grouping; i.e. if \code{norm.option == "by.group"}, rescaling is done within each group, and if \code{norm.option == "all"}, rescaling is done with all samples.
 }
-  
+
 \value{An object of class '\code{GENESIS.nullModel}' or '\code{GENESIS.nullMixedModel}'. A list including:
     \item{family}{A character string specifying the family used in the analysis.}
     \item{hetResid}{A logical indicator of whether heterogeneous residual variance components were used in the model (specified by \code{group.var}).}
@@ -105,16 +107,16 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
     %\item{Ytilde}{phenotype values adjusted for covariates and random effects. This adjusted phenotype vector approximately follow a distribution with mean 0 and an identity covariance matrix. Linear regression of this adjusted phenotype vector on an equivalently adjusted genotype vector provides the same estimates as fitting the full GLS model (by the Frisch-Waugh-Lovell theorem).}
     %\item{RSS0}{the sum of the `Ytilde` values squared. This is the sum of squared residuals under the null hypothesis of no genetic effect for the covariate and random effect adjusted model using the Frisch-Waugh-Lovell theorem.}
 }
-  
+
 \references{
     Chen H, Wang C, Conomos MP, Stilp AM, Li Z, Sofer T, Szpiro AA, Chen
     W, Brehm JM, Celedon JC, Redline S, Papanicolaou GJ, Thornton TA,
     Laurie CC, Rice K and Lin X. (2016) Control for Population Structure and
     Relatedness for Binary Traits in Genetic Association Studies Using
     Logistic Mixed Models. American Journal of Human Genetics, 98(4):653-66.
-    
+
     Breslow NE and Clayton DG. (1993). Approximate Inference in Generalized Linear Mixed Models. Journal of the American Statistical Association 88: 9-25.
-    
+
     Gilmour, A.R., Thompson, R., & Cullis, B.R. (1995). Average information REML: an efficient algorithm for variance parameter estimation in linear mixed models. Biometrics, 1440-1450.
 }
 
@@ -123,7 +125,7 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
 \seealso{
     \code{\link{varCompCI}} for estimating confidence intervals for the variance components and the proportion of variability (heritability) they explain, \code{\link{assocTestSingle}} or \code{\link{assocTestAggregate}} for running genetic association tests using the output from \code{fitNullModel}.
 }
-  
+
 \examples{
 library(GWASTools)
 
@@ -137,7 +139,7 @@ HapMap_genoData <- GenotypeData(HapMap_geno)
 data("HapMap_ASW_MXL_KINGmat")
 
 # run PC-AiR
-mypcair <- pcair(HapMap_genoData, kinobj = HapMap_ASW_MXL_KINGmat, 
+mypcair <- pcair(HapMap_genoData, kinobj = HapMap_ASW_MXL_KINGmat,
                 divobj = HapMap_ASW_MXL_KINGmat)
 
 # run PC-Relate
@@ -150,7 +152,7 @@ close(HapMap_genoData)
 set.seed(4)
 pheno <- 0.2*mypcair$vectors[,1] + rnorm(mypcair$nsamp, mean = 0, sd = 1)
 
-annot <- data.frame(sample.id = mypcair$sample.id, 
+annot <- data.frame(sample.id = mypcair$sample.id,
                     pc1 = mypcair$vectors[,1], pheno = pheno)
 
 # make covariance matrix

--- a/man/fitNullModel.Rd
+++ b/man/fitNullModel.Rd
@@ -63,7 +63,7 @@ nullModelInvNorm(null.model, cov.mat = NULL, norm.option = c("by.group", "all"),
 \details{
     If \code{x} is a data.frame, the rownames of \code{x} must match the row and column names of \code{cov.mat} (if \code{cov.mat} is specified). If \code{x} is an \code{\link{AnnotatedDataFrame}} or other object containing an \code{\link{AnnotatedDataFrame}}, \code{x} will be re-ordered (if necessary) so that \code{sample.id} or \code{scanID} is in the same order as the row and column names of \code{cov.mat}.
 
-    The code checks for collinear of the design matrix by checking that its rank is equal to the number of columns; if the rank is smaller, it fails with an error.
+    The code checks for multicollinearity of the design matrix by checking that its rank is equal to the number of columns; if the rank is smaller, it fails with an error.
 
     \code{cov.mat} is used to specify the covariance structures of the random effects terms in the model.  For example, to include a polygenic random effect, one matrix in \code{cov.mat} could be a kinship matrix or a genetic relationship matrix (GRM).  As another example, to include household membership as a random effect, one matrix in \code{cov.mat} should be a 0/1 matrix with a 1 in the \code{[i,j]} and \code{[j,i]} entries if individuals \code{i} and \code{j} are in the same household and 0 otherwise; the diagonals of such a matrix should all be 1.
 

--- a/tests/testthat/test_nullModel.R
+++ b/tests/testthat/test_nullModel.R
@@ -44,10 +44,10 @@ test_that("design matrix with collinear covariates", {
      expect_silent(fitNullModel(dat, outcome="a", covars = c("b", "c", "d")))
      # Simple case where one covariate equals another.
      expect_error(fitNullModel(dat, outcome="a", covars = c("b", "c", "d", "e")),
-                  "collinear")
+                  "multicollinearity")
      # Slightly more complicated case involving linear combination of more than one covariate.
      expect_error(fitNullModel(dat, outcome="a", covars = c("b", "c", "d", "f")),
-                  "collinear")
+                  "multicollinearity")
 })
 
 test_that("null model", {

--- a/tests/testthat/test_nullModel.R
+++ b/tests/testthat/test_nullModel.R
@@ -28,6 +28,28 @@ test_that("design matrix with missing reference level", {
     expect_equal(colnames(nm$model.matrix)[2], "by")
 })
 
+test_that("design matrix with collinear covariates", {
+    set.seed(20); a <- rnorm(10)
+    set.seed(21); c <- sample(1:10, 10, replace=TRUE)
+    dat <- data.frame(a=a,
+                      b=c(rep("a",5), rep("b", 5)),
+                      c=c,
+                      d=sample(1:10, 10, replace=TRUE),
+                      stringsAsFactors = FALSE)
+    dat$e <- dat$c
+    dat$f <- dat$c + 2 * dat$d
+    # No failure with no covariates.
+     expect_silent(nm <- fitNullModel(dat, outcome="a"))
+     # No failure with no colinear covariates.
+     expect_silent(fitNullModel(dat, outcome="a", covars = c("b", "c", "d")))
+     # Simple case where one covariate equals another.
+     expect_error(fitNullModel(dat, outcome="a", covars = c("b", "c", "d", "e")),
+                  "collinear")
+     # Slightly more complicated case involving linear combination of more than one covariate.
+     expect_error(fitNullModel(dat, outcome="a", covars = c("b", "c", "d", "f")),
+                  "collinear")
+})
+
 test_that("null model", {
     set.seed(22); a <- rnorm(10)
     dat <- data.frame(sample.id=letters[1:10],
@@ -108,10 +130,10 @@ test_that("dimnames for cov.mat", {
 
     dimnames(covMat) <- list(1:10, 1:10)
     expect_error(.checkSampleId(covMat, dat))
-    
-    rownames(dat) <- dat$sample.id  
+
+    rownames(dat) <- dat$sample.id
     expect_error(.checkRownames(covMat, dat))
-    
+
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
     .checkSampleId(covMat, dat)
 })
@@ -125,7 +147,7 @@ test_that("sample selection", {
     dat <- AnnotatedDataFrame(dat)
     set.seed(29); covMat <- crossprod(matrix(rnorm(100,sd=0.05),10,10))
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
-    
+
     keep <- rev(dat$sample.id[c(TRUE,FALSE)])
     nm <- fitNullModel(dat, outcome="a", covars="b", group.var="b", cov.mat=covMat, sample.id=keep, verbose=FALSE)
     expect_equal(nm$sample.id, rev(keep))
@@ -140,7 +162,7 @@ test_that("change sample order", {
     dat <- AnnotatedDataFrame(dat)
     set.seed(301); covMat <- crossprod(matrix(rnorm(100,sd=0.05),10,10))
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
-    
+
     nm <- fitNullModel(dat, outcome="a", covars="b", group.var="b", cov.mat=covMat, verbose=FALSE)
     expect_equal(nm$sample.id, dat$sample.id)
     expect_equal(rownames(nm$model.matrix), dat$sample.id)
@@ -170,7 +192,7 @@ test_that("inv norm", {
     nm <- fitNullModel(dat, outcome="a", covars="b", group.var="b", cov.mat=covMat, verbose=FALSE)
     inv <- nullModelInvNorm(nm, covMat, verbose=FALSE)
     expect_equal(nm$sample.id, inv$sample.id)
-    
+
     # change order of covMat with respect to dat
     dimnames(covMat) <- list(rev(dat$sample.id), rev(dat$sample.id))
     nm <- fitNullModel(dat, outcome="a", covars="b", group.var="b", cov.mat=covMat, verbose=FALSE)
@@ -185,13 +207,13 @@ test_that("outcome has colnames", {
 
     nullmod <- fitNullModel(df, outcome="outcome", covars="sex", verbose=FALSE)
     expect_equal(colnames(nullmod$outcome), "outcome")
-    
+
     nullmod <- fitNullModel(adf, outcome="outcome", covars="sex", verbose=FALSE)
     expect_equal(colnames(nullmod$outcome), "outcome")
-    
+
     nullmod <- fitNullModel(svd, outcome="outcome", covars="sex", verbose=FALSE)
     expect_equal(colnames(nullmod$outcome), "outcome")
-    
+
     seqClose(svd)
 })
 
@@ -272,7 +294,7 @@ test_that("tibbles are supported", {
                          b=c(rep("a",5), rep("b", 5)))
     set.seed(44); covMat <- crossprod(matrix(rnorm(100,sd=0.05),10,10))
     nm1 <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, verbose=FALSE)
-    
+
     dat <- AnnotatedDataFrame(dat)
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
     nm2 <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, verbose=FALSE)
@@ -288,7 +310,7 @@ test_that("data.tables are supported", {
                       b=c(rep("a",5), rep("b", 5)))
     set.seed(44); covMat <- crossprod(matrix(rnorm(100,sd=0.05),10,10))
     nm1 <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, verbose=FALSE)
-    
+
     dat <- AnnotatedDataFrame(dat)
     dimnames(covMat) <- list(dat$sample.id, dat$sample.id)
     nm2 <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, verbose=FALSE)


### PR DESCRIPTION
* Add an error in `createDesignMatrix` when some combination of covariates are collinear
* Add test to verify that error is produced when appropriate
* Update man page for `fitNullModel` to reflect this new error