### PR TITLE
Subset covariance matrix to samples in sample.id if specified

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Type: Package
 Title: GENetic EStimation and Inference in Structured samples
         (GENESIS): Statistical methods for analyzing genetic data from
         samples with population structure and/or relatedness
-Version: 2.23.8
+Version: 2.23.9
 Date: 2021-09-08
 Author: Matthew P. Conomos, Stephanie M. Gogarten,
 	Lisa Brown, Han Chen, Thomas Lumley, Kenneth Rice, Tamar Sofer, Adrienne Stilp, Timothy Thornton, Chaoyu Yu

--- a/R/fitNullModel.R
+++ b/R/fitNullModel.R
@@ -18,9 +18,9 @@ setMethod("fitNullModel",
                    drop.zeros = TRUE,
                    return.small = FALSE,
                    verbose = TRUE) {
-              
+
               family <- .checkFamily(family, two.stage)
-              
+
               if (is.data.table(x)) x <- as.data.frame(x)
 
               desmat <- createDesignMatrix(x, outcome, covars, group.var)
@@ -51,10 +51,10 @@ setMethod("fitNullModel",
 
               if(two.stage){
                   # fit the second stage model
-                  null.model <- nullModelInvNorm(null.model, cov.mat=cov.mat, 
-                                                 norm.option=norm.option, rescale=rescale, 
+                  null.model <- nullModelInvNorm(null.model, cov.mat=cov.mat,
+                                                 norm.option=norm.option, rescale=rescale,
                                                  AIREML.tol=AIREML.tol, max.iter=max.iter,
-                                                 EM.iter=EM.iter, drop.zeros=drop.zeros, 
+                                                 EM.iter=EM.iter, drop.zeros=drop.zeros,
                                                  return.small=return.small, verbose=verbose)
               }
 
@@ -74,10 +74,6 @@ setMethod("fitNullModel",
               if (is(x, "tbl")) x <- as.data.frame(x)
               rownames(x) <- x$sample.id
 
-              if (!is.null(cov.mat)) {
-                  .checkSampleId(cov.mat, x)
-              }
-
               ## subset data.frame and cov.mat for selected samples
               if (!is.null(sample.id)) {
                   stopifnot(all(sample.id %in% x$sample.id))
@@ -87,6 +83,10 @@ setMethod("fitNullModel",
                       ind <- which(.covMatNames(cov.mat) %in% sample.id)
                       cov.mat <- .covMatSubset(cov.mat, ind)
                   }
+              }
+
+              if (!is.null(cov.mat)) {
+                  .checkSampleId(cov.mat, x)
               }
 
               ## reorder data.frame to match cov.mat
@@ -124,7 +124,7 @@ setMethod("fitNullModel",
 
 ## function to check 'family' input
 .checkFamily <- function(family, two.stage=FALSE) {
-    
+
     if(is.character(family)){
         family <- get(family)
     }
@@ -137,11 +137,11 @@ setMethod("fitNullModel",
     if (!is.element(family$family, c("gaussian", "binomial", "poisson"))){
         stop("family must be one of gaussian, binomial, or poisson")
     }
-    
+
     if((two.stage) & (family$family != "gaussian")){
         stop('two stage model only applies when family is "gaussian"')
     }
-    
+
     return(family)
 }
 

--- a/R/fitNullModel.R
+++ b/R/fitNullModel.R
@@ -74,19 +74,17 @@ setMethod("fitNullModel",
               if (is(x, "tbl")) x <- as.data.frame(x)
               rownames(x) <- x$sample.id
 
-              ## subset data.frame and cov.mat for selected samples
-              if (!is.null(sample.id)) {
-                  stopifnot(all(sample.id %in% x$sample.id))
-                  ind <- x$sample.id %in% sample.id
-                  x <- x[ind,]
-                  if (!is.null(cov.mat)) {
-                      ind <- which(.covMatNames(cov.mat) %in% sample.id)
-                      cov.mat <- .covMatSubset(cov.mat, ind)
-                  }
-              }
+              if (is.null(sample.id)) sample.id <- x$sample.id
 
+              ## check if all requested samples are in x (and subset).
+              .checkXSampleId(x, sample.id)
+              x <- x[x$sample.id %in% sample.id, ]
+
+              ## check if all requested samples are in cov.mat (and subset).
               if (!is.null(cov.mat)) {
-                  .checkSampleId(cov.mat, x)
+                .checkCovMatSampleId(cov.mat, sample.id)
+                ind <- which(.covMatNames(cov.mat) %in% sample.id)
+                cov.mat <- .covMatSubset(cov.mat, ind)
               }
 
               ## reorder data.frame to match cov.mat
@@ -203,14 +201,20 @@ setMethod("fitNullModel",
 }
 
 
-## match sample.id between cov.mat and data frame
-.checkSampleId <- function(cov.mat, x) {
-    nms <- .covMatNames(cov.mat)
-    if (is.null(nms)) {
-        stop("provide sample.id in rownames and/or colnames of cov.mat")
-    } else if (!all(nms %in% x$sample.id)) {
-        stop("all sample names in dimnames of cov.mat must be present in x$sample.id")
-    }
+## check if a set of samples are in the data
+.checkXSampleId <- function(x, sample.id) {
+  if (!all(sample.id %in% x$sample.id)) {
+    stop("all samples in sample.id must be present in x")
+  }
+}
+
+.checkCovMatSampleId <- function(cov.mat, sample.id) {
+  nms <- .covMatNames(cov.mat)
+  if (is.null(nms)) {
+      stop("provide sample.id in rownames and/or colnames of cov.mat")
+  } else if (!all(sample.id %in% nms)) {
+      stop("all samples in sample.id must be present in dimnames of cov.mat")
+  }
 }
 
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,5 +1,10 @@
 \name{NEWS}
 \title{NEWS for GENESIS}
+\section{Version 2.23.9}{
+  \itemize{
+    \item Subset covariance matrix to specified samples when sample.id argument is passed to fitNullModel when called with an AnnotatedDataFrame
+    }
+}
 \section{Version 2.23.8}{
   \itemize{
     \item Added option for recessive and dominant coding to assocTestSingle.

--- a/tests/testthat/test_assocTestSingle.R
+++ b/tests/testthat/test_assocTestSingle.R
@@ -59,7 +59,7 @@ test_that("assocTestSingle - reorder samples", {
     set.seed(51); samp <- sample(sampleData(svd)$sample.id, 50)
     grm <- .testGRM(svd)
     iterator <- SeqVarBlockIterator(svd, variantBlock=500, verbose=FALSE)
-    nullmod <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp,samp], verbose=FALSE)
+    nullmod <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp,samp], sample.id=samp, verbose=FALSE)
     expect_equal(nrow(nullmod$model.matrix), 50)
     expect_equal(nullmod$fit$sample.id, samp)
     assoc <- assocTestSingle(iterator, nullmod, BPPARAM=BPPARAM, verbose=FALSE)
@@ -67,7 +67,7 @@ test_that("assocTestSingle - reorder samples", {
 
     # check that we get same assoc results with samples in different order
     samp.sort <- sort(samp)
-    nullmod2 <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp.sort,samp.sort], verbose=FALSE)
+    nullmod2 <- fitNullModel(iterator, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp.sort,samp.sort], sample.id=samp, verbose=FALSE)
     expect_equal(nullmod2$fit$sample.id, samp.sort)
     resetIterator(iterator, verbose=FALSE)
     assoc2 <- assocTestSingle(iterator, nullmod2, BPPARAM=BPPARAM, verbose=FALSE)
@@ -84,7 +84,7 @@ test_that("reorder genotypes", {
     svd <- .testData()
     grm <- .testGRM(svd)
     set.seed(52); samp <- sample(sampleData(svd)$sample.id, 50)
-    nullmod <- fitNullModel(svd, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp,samp], verbose=FALSE)
+    nullmod <- fitNullModel(svd, outcome="outcome", covars=c("sex", "age"), cov.mat=grm[samp,samp], sample.id=samp, verbose=FALSE)
     sample.index <- .setFilterNullModel(svd, nullmod, verbose=FALSE)
     geno <- expandedAltDosage(svd, use.names=TRUE, sparse=TRUE)[sample.index,,drop=FALSE]
     expect_equal(rownames(geno), samp)

--- a/tests/testthat/test_assocTestSingle_GenotypeIterator.R
+++ b/tests/testthat/test_assocTestSingle_GenotypeIterator.R
@@ -52,14 +52,14 @@ test_that("assocTestSingle - reorder samples", {
     set.seed(82); samp <- as.character(sample(getScanID(genoData), 50))
     iterator <- GenotypeBlockIterator(genoData, snpBlock=1000)
 
-    nullmod <- fitNullModel(genoData, outcome="outcome", cov.mat=covMat[samp,samp], verbose=FALSE)
+    nullmod <- fitNullModel(genoData, outcome="outcome", cov.mat=covMat[samp,samp], sample.id=samp, verbose=FALSE)
     assoc <- assocTestSingle(iterator, nullmod, BPPARAM=BPPARAM, verbose=FALSE)
     expect_equal(nrow(nullmod$model.matrix), 50)
     expect_equal(nullmod$fit$sample.id, samp)
 
     # check that we get same assoc results with samples in different order
     samp.sort <- sort(samp)
-    nullmod2 <- fitNullModel(genoData, outcome="outcome", cov.mat=covMat[samp.sort,samp.sort], verbose=FALSE)
+    nullmod2 <- fitNullModel(genoData, outcome="outcome", cov.mat=covMat[samp.sort,samp.sort], sample.id=samp, verbose=FALSE)
     expect_equal(nullmod2$fit$sample.id, samp.sort)
     GWASTools::resetIterator(iterator)
     assoc2 <- assocTestSingle(iterator, nullmod2, BPPARAM=BPPARAM, verbose=FALSE)
@@ -125,10 +125,10 @@ test_that("MatrixGenotypeReader", {
 test_that("recessive", {
     genoData <- .testGenoData()
     iterator <- GenotypeBlockIterator(genoData)
-    
+
     nullmod <- fitNullModel(genoData, outcome="outcome", covars="sex", verbose=FALSE)
     assoc <- assocTestSingle(iterator, nullmod, geno.coding="recessive", BPPARAM=BPPARAM, verbose=FALSE)
     expect_true("n.hom.eff" %in% names(assoc))
-    
+
     close(genoData)
 })

--- a/tests/testthat/test_nullModel.R
+++ b/tests/testthat/test_nullModel.R
@@ -100,6 +100,25 @@ test_that("null model - cov.mat", {
     expect_false(nm$model$hetResid)
 })
 
+
+test_that("null model - cov.mat with extra samples", {
+    set.seed(23); a <- rnorm(10)
+    dat <- data.frame(sample.id=letters[1:10],
+                      a=a,
+                      b=c(rep("a",5), rep("b", 5)),
+                      stringsAsFactors=FALSE)
+    dat <- AnnotatedDataFrame(dat)
+    set.seed(24); covMat <- crossprod(matrix(rnorm(11^2,sd=0.05),11,11))
+    rownames(covMat) <- colnames(covMat) <- letters[1:11]
+    expect_error(fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, verbose=FALSE), "dimnames of cov.mat must be present")
+    sample_include <- dat$sample.id[1:9]
+    nm <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat, sample.id = sample_include, verbose=FALSE)
+    chk <- fitNullModel(dat, outcome="a", covars="b", cov.mat=covMat[sample_include, sample_include], verbose=FALSE)
+    expect_equal(nm$fit$sample.id, sample_include)
+    expect_equal(nm$fit, chk$fit)
+    expect_equivalent(nm$fit$workingY, dat$a[dat$sample.id %in% sample_include])
+})
+
 test_that("null model from data.frame", {
     set.seed(25); a <- rnorm(10)
     dat <- data.frame(a=a,


### PR DESCRIPTION
* When fitting a null model with an AnnotatedDataFrame, `fitNullModel` will subset `cov.mat` to the samples specified in `sample.id` before checking for consistency with `x`.
* Add a unit test for this behavior

Is this too confusing of a change to make?

_Edited after some additional commits_: this pull request also modifies the null model code such that all samples in the `x` AnnotatedDataFrame are required to be in `cov.mat`. If `sample.id` is passed, subset both `x` and `cov.mat` to the samples in `sample.id`.